### PR TITLE
docs: fix simple typo, whenver -> whenever

### DIFF
--- a/lib/parhash.c
+++ b/lib/parhash.c
@@ -109,7 +109,7 @@ SymCryptParallelHashSetNextWork( PCSYMCRYPT_PARALLEL_HASH pParHash, PSYMCRYPT_PA
         // STATE_PAD2:      We are working on the next operation (a result), and have processed the first half of a 2-block padding.
         // STATE_RESULT:    We are working on the next operation (a result), and have processed all the padding.
         //
-        // The pState->dataLength is updated whenver we copy bytes from the append into the state's buffer, or when
+        // The pState->dataLength is updated whenever we copy bytes from the append into the state's buffer, or when
         //      we return TRUE and process bulk data.
         //
         pOp = pScratch->next;

--- a/lib/sha256Par.c
+++ b/lib/sha256Par.c
@@ -204,7 +204,7 @@ SymCryptParallelSha256SetNextWork( PSYMCRYPT_PARALLEL_HASH_SCRATCH_STATE pScratc
         // STATE_PAD2:      We are working on the next operation (a result), and have processed the first half of a 2-block padding.
         // STATE_RESULT:    We are working on the next operation (a result), and have processed all the padding.
         //
-        // The pState->dataLength is updated whenver we copy bytes from the append into the state's buffer, or when
+        // The pState->dataLength is updated whenever we copy bytes from the append into the state's buffer, or when
         //      we return TRUE and process bulk data.
         //
         pOp = pScratch->next;


### PR DESCRIPTION
There is a small typo in lib/parhash.c, lib/sha256Par.c.

Should read `whenever` rather than `whenver`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md