### PR TITLE
Fix ISO C/C++ violations, enable IPO / LTO / LTCG on Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ bin/
 CMakeFiles
 CMakeCache.txt
 **/cmake_install.*
+cmake-*
 
 # Visual Studio project/solution files from CMake
 *.vcxproj

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,13 +43,84 @@ endif()
 
 message(STATUS "Host: ${CMAKE_HOST_SYSTEM_NAME} ${CMAKE_HOST_SYSTEM_PROCESSOR}")
 message(STATUS "Target: ${CMAKE_SYSTEM_NAME} ${CMAKE_SYSTEM_PROCESSOR} ${SYMCRYPT_TARGET_ENV}")
+message(STATUS "Compiler: ${CMAKE_CXX_COMPILER_ID}")
 
 # Set output directories binaries
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib/${CMAKE_SYSTEM_PROCESSOR}/${SYMCRYPT_TARGET_ENV})
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/module/${CMAKE_SYSTEM_PROCESSOR}/${SYMCRYPT_TARGET_ENV})
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/exe/${CMAKE_SYSTEM_PROCESSOR}/${SYMCRYPT_TARGET_ENV})
 
-if(WIN32)
+enable_language(C)
+enable_language(CXX)
+
+function(find_windows_sdk)
+
+    # Find the Windows Kits directory.
+    get_filename_component(windows_kits_dir
+            "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots;KitsRoot10]" ABSOLUTE)
+    set(programfilesx86 "ProgramFiles(x86)")
+    if (";${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION};$ENV{UCRTVersion};$ENV{WindowsSDKVersion};" MATCHES [=[;(10\.[0-9.]+)[;\]]]=])
+        set(__ucrt_version "${CMAKE_MATCH_1}/")
+    else ()
+        set(__ucrt_version "*/")
+    endif ()
+
+    if (NOT DEFINED CMAKE_MSVC_ARCH)
+        if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "^ARM")
+            set(CMAKE_MSVC_ARCH "arm")
+        elseif (${CMAKE_SYSTEM_PROCESSOR} MATCHES "64$")
+            set(CMAKE_MSVC_ARCH "x64")
+        else ()
+            set(CMAKE_MSVC_ARCH "x86")
+        endif ()
+    endif ()
+
+
+    set(WINDOWS_KITS_DIR "" PARENT_SCOPE)
+    find_path(WINDOWS_KITS_DIR
+            NAMES
+            "Redist/${__ucrt_version}ucrt/DLLs/${CMAKE_MSVC_ARCH}/ucrtbase.dll"
+            "Redist/ucrt/DLLs/${CMAKE_MSVC_ARCH}/ucrtbase.dll"
+            PATHS
+            $ENV{CMAKE_WINDOWS_KITS_10_DIR}
+            "${windows_kits_dir}"
+            "$ENV{ProgramFiles}/Windows Kits/10"
+            "$ENV{${programfilesx86}}/Windows Kits/10"
+    )
+    mark_as_advanced(WINDOWS_KITS_DIR)
+
+    set(WINDOWSSDK_VERSIONS "" PARENT_SCOPE)
+
+    file(GLOB WINDOWSSDK_VERSIONS
+            LIST_DIRECTORIES true
+            RELATIVE "${WINDOWS_KITS_DIR}/Include"
+            "${WINDOWS_KITS_DIR}/Include/*"
+    )
+    mark_as_advanced(WINDOWSSDK_VERSIONS)
+
+    set(WINDOWSSDK_VERSION "" PARENT_SCOPE)
+    set(_WINDOWSSDK_VERSIONS "${WINDOWSSDK_VERSIONS}")
+    list(GET _WINDOWSSDK_VERSIONS 0 WINDOWSSDK_VERSION)
+    list(REMOVE_AT _WINDOWSSDK_VERSIONS 0)
+    foreach(__version "${_WINDOWSSDK_VERSIONS}")
+        if ("${__version}" VERSION_GREATER "${WINDOWSSDK_VERSION}")
+            set(WINDOWSSDK_VERSION "${__version}")
+        endif ()
+    endforeach()
+    mark_as_advanced(WINDOWSSDK_VERSION)
+
+    set(WINDOWSSDK_INCLUDE_ROOT "${WINDOWS_KITS_DIR}/Include/${WINDOWSSDK_VERSION}" PARENT_SCOPE)
+    mark_as_advanced(WINDOWSSDK_INCLUDE_ROOT)
+
+    set(WINDOWSSDK_INCLUDE_DIRS "${WINDOWSSDK_INCLUDE_ROOT}/shared;${WINDOWSSDK_INCLUDE_ROOT}/um" PARENT_SCOPE)
+    mark_as_advanced(WINDOWSSDK_INCLUDE_DIRS)
+
+endfunction()
+
+
+if(MSVC)
+    find_windows_sdk()
+
     if(NOT SYMCRYPT_TARGET_ENV MATCHES "Generic")
         # Enable ASM_MASM. Annoyingly, this has to be done in the main CMake file rather than in the
         # toolchain file
@@ -76,6 +147,12 @@ if(WIN32)
         add_compile_options(/Gw)
     endif()
 else()
+    if(WIN32)
+        find_windows_sdk()
+        include_directories(SYSTEM "${WINDOWSSDK_INCLUDE_ROOT}")
+        add_compile_definitions(_WIN32_WINNT=0x0A00)
+    endif()
+
     if(NOT SYMCRYPT_TARGET_ENV MATCHES "Generic")
         enable_language(ASM)
         # Suppress noisy warnings about compile options which are ignored for ASM
@@ -154,8 +231,24 @@ else()
     endif()
 endif()
 
+option(RELEASE_USES_IPO "Enable IPO/LTO/LTCG for Release builds." ON)
+
 if(CMAKE_BUILD_TYPE MATCHES Release)
     message("Release mode")
+
+    include(CheckIPOSupported)
+    check_ipo_supported(RESULT HAVE_IPO_SUPPORT OUTPUT IPO_SUPPORT_ERROR)
+
+    if (HAVE_IPO_SUPPORT)
+        if (RELEASE_USES_IPO)
+            message(STATUS "IPO/LTO/LTCG: supported, enabled")
+            set_property(GLOBAL PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+        else ()
+            message(STATUS "IPO/LTO/LTCG: supported, disabled")
+        endif ()
+    else ()
+        message(STATUS "IPO/LTO/LTCG: not supported, <${IPO_SUPPORT_ERROR}>")
+    endif ()
 else()
     message("Debug mode")
     add_compile_options(-DDBG=1)

--- a/gen/main_gen.cpp
+++ b/gen/main_gen.cpp
@@ -18,7 +18,12 @@ Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 #pragma push_macro("NTDDI_VERSION")
 #undef NTDDI_VERSION
 #define NTDDI_VERSION NTDDI_WINTHRESHOLD
+#if WIN32 && __GNUC__
+#include <um/wincrypt.h>
+#include <shared/bcrypt.h>
+#else
 #include <bcrypt.h>
+#endif
 #pragma pop_macro("NTDDI_VERSION")
 
 #include <stdio.h>
@@ -167,7 +172,7 @@ printSmallPrimeDifferences( FILE * f, UINT32 primeLimit )
     UINT32 i;
     UINT32 nCache = 0;
     UINT32 nNibbles = 0;
-    char * sep = NULL;
+    const char * sep = NULL;
     UINT32 nib;
     UINT32 diff;
     UINT32 nBytes = 0;
@@ -516,7 +521,7 @@ printIfxTpmWeakKeyTable( FILE * f )
         UINT32 p = primeInfo[i].prime;
         UINT32 nBytes = (p + 7)/8;
         UINT32 count;
-        char * sep = "";
+        const char * sep = "";
 
         fprintf( f, "\n\n    // %d\n    ", p );
         buildGeneratorBitmap( p, 65537, &workBuffer[0], &count );
@@ -552,7 +557,7 @@ printIfxTpmWeakKeyTable( FILE * f )
         if( n < p-1 )
         {
             fprintf( f, "{ %3d, ", p);
-            char * sep = "{";
+            const char * sep = "{";
             for( UINT32 j=0; j<nBytesInTable; j++ )
             {
                 fprintf( f, "%s 0x%02x", sep, buf[j] );

--- a/inc/symcrypt_no_sal.h
+++ b/inc/symcrypt_no_sal.h
@@ -9,46 +9,124 @@
 // environments without SAL, such as iOS or Android.
 //
 
+#ifndef _Success_
 #define _Success_(x)
+#endif
+#ifndef _Analysis_noreturn_
+#ifdef __GNUC__
+#define _Analysis_noreturn_ [[gnu::noreturn]]
+#else
 #define _Analysis_noreturn_
+#endif
+#endif
+#ifndef _Analysis_assume_
 #define _Analysis_assume_(x)
+#endif
+#ifndef __analysis_assume
 #define __analysis_assume(x)
+#endif
 
+#ifndef _Use_decl_annotations_
 #define _Use_decl_annotations_
+#endif
 
+#ifndef __in
 #define __in
+#endif
+#ifndef __in_opt
 #define __in_opt
+#endif
+#ifndef __inout_ecount
 #define __inout_ecount(x)
+#endif
+#ifndef __out_ecount
 #define __out_ecount(x)
+#endif
 
+#ifndef _In_
 #define _In_
+#endif
+#ifndef _In_z_
 #define _In_z_
+#endif
+#ifndef _In_z_b
 #define _In_z_b
+#endif
+#ifndef _In_opt_
 #define _In_opt_
+#endif
+#ifndef _In_range_
 #define _In_range_(x,y)
+#endif
+#ifndef _In_reads_
 #define _In_reads_(x)
+#endif
+#ifndef _In_reads_opt_
 #define _In_reads_opt_(x)
+#endif
+#ifndef _In_reads_bytes_
 #define _In_reads_bytes_(x)
+#endif
+#ifndef _In_reads_bytes_opt_
 #define _In_reads_bytes_opt_(x)
+#endif
 
+#ifndef _Out_
 #define _Out_
+#endif
+#ifndef _Out_opt_
 #define _Out_opt_
+#endif
+#ifndef _Out_writes_
 #define _Out_writes_(x)
+#endif
+#ifndef _Out_writes_to_
 #define _Out_writes_to_(x,y)
+#endif
+#ifndef _Out_writes_opt_
 #define _Out_writes_opt_(x)
+#endif
+#ifndef _Out_writes_bytes_
 #define _Out_writes_bytes_(x)
+#endif
+#ifndef _Out_writes_bytes_to_
 #define _Out_writes_bytes_to_(x,y)
+#endif
+#ifndef _Out_writes_bytes_all_opt_
 #define _Out_writes_bytes_all_opt_(x)
+#endif
+#ifndef _Out_writes_bytes_opt_
 #define _Out_writes_bytes_opt_(x)
+#endif
 
+#ifndef _Inout_
 #define _Inout_
+#endif
+#ifndef _Inout_updates_
 #define _Inout_updates_(x)
+#endif
+#ifndef _Inout_updates_bytes_
 #define _Inout_updates_bytes_(x)
+#endif
+#ifndef _Inout_updates_opt_
 #define _Inout_updates_opt_(x)
+#endif
 
+#ifndef _Field_size_
 #define _Field_size_(x)
+#endif
+#ifndef _Field_range_
 #define _Field_range_(x,y)
+#endif
 
+#ifndef _Ret_range_
 #define _Ret_range_(x,y)
+#endif
 
+#ifndef _Must_inspect_result_
 #define _Must_inspect_result_
+#endif
+
+#ifndef __callback
+#define __callback
+#endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -277,7 +277,7 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64")
     endif()
 endif()
 
-if(WIN32)
+if(MSVC)
     # Disable run-time type information for SymCrypt library - we do not use it
     add_compile_options(/GR-)
 
@@ -310,7 +310,7 @@ if(WIN32)
     target_link_libraries(symcrypt_windows10sgx symcrypt_common)
 endif()
 
-if(NOT WIN32)
+if(NOT MSVC)
     add_compile_options(-Wno-trigraphs)
 
     # Mitigate stack buffer overruns, and stack clash attacks
@@ -328,14 +328,37 @@ if(NOT WIN32)
         endif()
     endif()
 
-    add_library(symcrypt_linuxusermode STATIC env_linuxUserMode.c)
-    set_target_properties(symcrypt_linuxusermode PROPERTIES PREFIX "")
-    target_link_libraries(symcrypt_linuxusermode symcrypt_common)
+    if (WIN32)
+
+        add_library(symcrypt_usermodewin7 STATIC env_windowsUserModeWin7.c)
+        set_target_properties(symcrypt_usermodewin7 PROPERTIES PREFIX "")
+        target_link_libraries(symcrypt_usermodewin7 symcrypt_common ssp)
+
+        add_library(symcrypt_usermodewin8_1 STATIC env_windowsUserModeWin8_1.c)
+        set_target_properties(symcrypt_usermodewin8_1 PROPERTIES PREFIX "")
+        target_link_libraries(symcrypt_usermodewin8_1 symcrypt_common ssp)
+
+        add_library(symcrypt_windowskerneldebugger STATIC env_windowsKernelDebugger.c)
+        set_target_properties(symcrypt_windowskerneldebugger PROPERTIES PREFIX "")
+        target_link_libraries(symcrypt_windowskerneldebugger symcrypt_common ssp)
+
+        add_library(symcrypt_windows10sgx STATIC env_win10Sgx.c)
+        set_target_properties(symcrypt_windows10sgx PROPERTIES PREFIX "")
+        target_link_libraries(symcrypt_windows10sgx symcrypt_common ssp)
+    else ()
+        add_library(symcrypt_linuxusermode STATIC env_linuxUserMode.c)
+        set_target_properties(symcrypt_linuxusermode PROPERTIES PREFIX "")
+        target_link_libraries(symcrypt_linuxusermode symcrypt_common)
+    endif ()
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/inc)
 
 add_library(symcrypt_common STATIC ${SOURCES_COMMON})
+
+if (NOT MSVC AND WIN32)
+    target_link_libraries(symcrypt_common ssp)
+endif ()
 
 add_library(symcrypt_generic STATIC env_generic.c)
 set_target_properties(symcrypt_generic PROPERTIES PREFIX "")

--- a/lib/cpuid.c
+++ b/lib/cpuid.c
@@ -350,7 +350,7 @@ SymCryptDetectCpuFeaturesFromRegisters()
         SYMCRYPT_CPU_FEATURE_NEON_SHA256
         );
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
     try {
 
         if( READ_ARM64_FEATURE(ARM64_ID_AA64ISAR0_EL1, ISAR0_AES) < ISAR0_AES_INSTRUCTIONS )

--- a/lib/env_Win10Sgx.c
+++ b/lib/env_Win10Sgx.c
@@ -18,6 +18,9 @@ SYMCRYPT_CPU_FEATURES SYMCRYPT_CALL SymCryptCpuFeaturesNeverPresentEnvWin10Sgx()
 #endif    
 }
 
+#if WIN32 && __GNUC__
+[[gnu::optimize("no-stack-clash-protection")]]
+#endif
 _Analysis_noreturn_
 VOID
 SYMCRYPT_CALL
@@ -50,6 +53,12 @@ SymCryptFatalEnvWin10Sgx( UINT32 fatalCode )
     //
 
     SymCryptFatalHang( fatalCode );
+
+#if WIN32 && __GNUC__
+    // ICE in seh_emit_stackalloc, disable stack-clash-protection for this func
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458
+    __builtin_unreachable();
+#endif
 }
 
 VOID

--- a/lib/env_generic.c
+++ b/lib/env_generic.c
@@ -44,6 +44,9 @@ SymCryptInitEnvGeneric( UINT32 version )
     SymCryptInitEnvCommon( version );
 }
 
+#if WIN32 && __GNUC__
+[[gnu::optimize("no-stack-clash-protection")]]
+#endif
 _Analysis_noreturn_
 VOID 
 SYMCRYPT_CALL 
@@ -71,6 +74,12 @@ SymCryptFatalEnvGeneric( UINT32 fatalCode )
     SYMCRYPT_FORCE_WRITE32( (volatile UINT32 *)NULL, fatalCode );
 
     SymCryptFatalHang( fatalCode );
+
+#if WIN32 && __GNUC__
+    // ICE in seh_emit_stackalloc, disable stack-clash-protection for this func
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458
+    __builtin_unreachable();
+#endif
 }
 
 #if SYMCRYPT_CPU_AMD64 | SYMCRYPT_CPU_X86

--- a/lib/env_linuxUserMode.c
+++ b/lib/env_linuxUserMode.c
@@ -31,7 +31,7 @@ SymCryptInitEnvLinuxUsermode( UINT32 version )
     //
     g_SymCryptCpuFeaturesNotPresent |= SYMCRYPT_CPU_FEATURE_AVX2;
 
-    #if SYMCRYPT_MS_VC
+    #if SYMCRYPT_MS_VC || WIN32
     if( (GetEnabledXStateFeatures() & XSTATE_MASK_AVX) != 0 )
     {
         g_SymCryptCpuFeaturesNotPresent &= ~SYMCRYPT_CPU_FEATURE_AVX2;

--- a/lib/env_windowsKernelDebugger.c
+++ b/lib/env_windowsKernelDebugger.c
@@ -32,6 +32,9 @@ SymCryptInitEnvWindowsKernelDebugger( UINT32 version )
     SymCryptInitEnvCommon( version );
 }
 
+#if WIN32 && __GNUC__
+[[gnu::optimize("no-stack-clash-protection")]]
+#endif
 _Analysis_noreturn_
 VOID 
 SYMCRYPT_CALL 
@@ -59,6 +62,12 @@ SymCryptFatalEnvWindowsKernelDebugger( UINT32 fatalCode )
     SYMCRYPT_FORCE_WRITE32( (volatile UINT32 *)NULL, fatalCode );
 
     SymCryptFatalHang( fatalCode );
+
+#if WIN32 && __GNUC__
+    // ICE in seh_emit_stackalloc, disable stack-clash-protection for this func
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458
+    __builtin_unreachable();
+#endif
 }
 
 #if SYMCRYPT_CPU_AMD64 | SYMCRYPT_CPU_X86

--- a/lib/env_windowsUserModeWin7.c
+++ b/lib/env_windowsUserModeWin7.c
@@ -7,7 +7,13 @@
 
 // #include "precomp.h"
 
+#ifdef __MINGW64__
+#define NOCRYPT
+#endif
 #include <Windows.h>
+#ifdef __MINGW64__
+#undef NOCRYPT
+#endif
 #include "symcrypt.h"
 #include "sc_lib.h"
 
@@ -71,6 +77,9 @@ SymCryptInitEnvWindowsUsermodeWin7nLater( UINT32 version )
     SymCryptInitEnvCommon( version );
 }
 
+#if WIN32 && __GNUC__
+[[gnu::optimize("no-stack-clash-protection")]]
+#endif
 _Analysis_noreturn_
 VOID 
 SYMCRYPT_CALL 
@@ -106,6 +115,12 @@ SymCryptFatalEnvWindowsUsermodeWin7nLater( UINT32 fatalCode )
     TerminateProcess( GetCurrentProcess(), fatalCode );
 
     SymCryptFatalHang( fatalCode );
+
+#if WIN32 && __GNUC__
+    // ICE in seh_emit_stackalloc, disable stack-clash-protection for this func
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458
+    __builtin_unreachable();
+#endif
 }
 
 #if SYMCRYPT_CPU_AMD64 | SYMCRYPT_CPU_X86

--- a/lib/env_windowsUserModeWin8_1.c
+++ b/lib/env_windowsUserModeWin8_1.c
@@ -6,7 +6,13 @@
 //
 
 //#include "precomp.h"
+#ifdef __MINGW64__
+#define NOCRYPT
+#endif
 #include <Windows.h>
+#ifdef __MINGW64__
+#undef NOCRYPT
+#endif
 #include "symcrypt.h"
 #include "sc_lib.h"
 
@@ -57,6 +63,9 @@ SymCryptInitEnvWindowsUsermodeWin8_1nLater( UINT32 version )
     SymCryptInitEnvCommon( version );
 }
 
+#if WIN32 && __GNUC__
+[[gnu::optimize("no-stack-clash-protection")]]
+#endif
 _Analysis_noreturn_
 VOID 
 SYMCRYPT_CALL 
@@ -92,6 +101,12 @@ SymCryptFatalEnvWindowsUsermodeWin8_1nLater( UINT32 fatalCode )
     TerminateProcess( GetCurrentProcess(), fatalCode );
 
     SymCryptFatalHang( fatalCode );
+
+#if WIN32 && __GNUC__
+    // ICE in seh_emit_stackalloc, disable stack-clash-protection for this func
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90458
+    __builtin_unreachable();
+#endif
 }
 
 #if SYMCRYPT_CPU_AMD64 | SYMCRYPT_CPU_X86

--- a/lib/sc_lib.h
+++ b/lib/sc_lib.h
@@ -1525,7 +1525,7 @@ extern const BYTE SymCryptSha512KATAnswer[64];
 #define SYMCRYPT_OBJ_NBYTES( _p )               ((_p)->nDigits * SYMCRYPT_FDEF_DIGIT_SIZE)
 #define SYMCRYPT_OBJ_NUINT32( _p )              ((_p)->nDigits * SYMCRYPT_FDEF_DIGIT_SIZE / sizeof( UINT32 ))
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
 #define SYMCRYPT_MUL32x32TO64( _a, _b )         UInt32x32To64( (_a), (_b) )
 #elif SYMCRYPT_GNUC
 #define SYMCRYPT_MUL32x32TO64( _a, _b )         ( (unsigned long)(_a)*(unsigned long)(_b) )
@@ -3448,7 +3448,9 @@ SymCryptPositiveWidthNafRecoding(
 // Ingnore the incompatible pointer types void * to PSYMCRYPT_XXX
 #pragma GCC diagnostic ignored "-Wincompatible-pointer-types"
 
+#ifndef FIELD_OFFSET
 #define FIELD_OFFSET(type,field)    ((UINT32)(uintptr_t)&(((type *)0)->field))
+#endif
 
 #define __fastfail(x)               (*((volatile int *)(0)) = (int) (x))
 
@@ -3473,7 +3475,7 @@ SymCryptPositiveWidthNafRecoding(
 //   SEQ_CST corresponds to sequentially consistent memory ordering in C++11
 //
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
 #include <intrin.h>
 
 #if SYMCRYPT_CPU_ARM64
@@ -3556,7 +3558,7 @@ SymCryptInlineInterlockedAdd64( volatile LONG64* destination, LONG64 value )
 
 #if SYMCRYPT_CPU_AMD64 | SYMCRYPT_CPU_ARM64
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
 
 #if SYMCRYPT_CPU_ARM64
 #define SYMCRYPT_MSVC_CAS128_NF _InterlockedCompareExchange128_nf

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -1189,7 +1189,7 @@ SymCryptSha256AppendBlocks_xmm2(
 // SHA-NI Implementation
 //
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
 // Intrinsic definitions included here
 // until the header is updated.
 // *******************************

--- a/unittest/iOS/helper.mm
+++ b/unittest/iOS/helper.mm
@@ -9,7 +9,7 @@
 #include "precomp.h"
 
 KatData * 
-getCustomResource( PSTR resourceName, PSTR resourceType )
+getCustomResource( PCSTR resourceName, PCSTR resourceType )
 {
     UNREFERENCED_PARAMETER(resourceType);
     

--- a/unittest/inc/algorithm_base.h
+++ b/unittest/inc/algorithm_base.h
@@ -59,7 +59,7 @@ public:
     {
         SIZE_T                  keySize;        // key size to add to row header. (0 if not used)
         SIZE_T                  dataSize;       // data size to add to row header. (only used with g_measure_specific_sizes)
-        char *                  strPostfix;     // postfix string, must be 3 characters long
+        const char *            strPostfix;     // postfix string, must be 3 characters long
         double                  cFixed;         // clocks of fixed overhead.
         double                  cPerByte;       // clocks average cost per byte (used only for linear records, 0 for non-linear records)
         double                  cRange;         // 90 percentile of deviation from prediction by previous two numbers

--- a/unittest/inc/capi_implementations.h
+++ b/unittest/inc/capi_implementations.h
@@ -14,7 +14,7 @@ extern HCRYPTPROV g_capiProvider;
 //
 class ImpCapi{
 public:
-    static char * name;
+    static const char * name;
 };
 
 //

--- a/unittest/inc/cng_implementations.h
+++ b/unittest/inc/cng_implementations.h
@@ -16,7 +16,7 @@ AddBCryptBuffer( BCryptBufferDesc * pBufferDesc, ULONG BufferType, PCVOID pData,
 //
 class ImpCng{
 public:
-    static char * name;
+    static const char * name;
 };
 
 

--- a/unittest/inc/kat.h
+++ b/unittest/inc/kat.h
@@ -42,7 +42,7 @@ typedef struct _KAT_RECORD
 class KatData
 {
 public:
-    KatData( _In_ PSTR name, _In_ PCCHAR pbData, SIZE_T cbData );
+    KatData( _In_ PCSTR name, _In_ PCCHAR pbData, SIZE_T cbData );
     // Provide name, pointer, and length of data to be parsed
     ~KatData() {};
 
@@ -68,7 +68,7 @@ public:
     PCCHAR      m_pbData;           // Current data location
     PCCHAR      m_pbEnd;            // End of data
     LONGLONG    m_line;             // Current line number
-    LPSTR       m_name;             // Name of file/resource
+    LPCSTR      m_name;             // Name of file/resource
 
     LONGLONG    line();
 

--- a/unittest/inc/msbignum_implementations.h
+++ b/unittest/inc/msbignum_implementations.h
@@ -16,7 +16,7 @@
 
 class ImpMsBignum{
 public:
-    static char * name;
+    static const char * name;
 };
 
 template<>

--- a/unittest/inc/perf.h
+++ b/unittest/inc/perf.h
@@ -29,5 +29,5 @@ typedef VOID (*PerfCleanFn)( PBYTE buf1, PBYTE buf2, PBYTE buf3 );
 
 VOID measurePerf();
 
-extern PSTR g_perfUnits;
+extern PCSTR g_perfUnits;
 

--- a/unittest/inc/ref_implementations.h
+++ b/unittest/inc/ref_implementations.h
@@ -9,7 +9,7 @@
 //
 class ImpRef{
 public:
-    static char * name;
+    static const char * name;
 };
 
 typedef struct _REF_POLY1305_STATE {

--- a/unittest/inc/rndDriver.h
+++ b/unittest/inc/rndDriver.h
@@ -7,7 +7,7 @@
 typedef VOID (* RNDD_TEST_FN)();
 
 VOID
-rnddRegisterTestFunction( RNDD_TEST_FN func, _In_ PSTR name, UINT32 weight );
+rnddRegisterTestFunction( RNDD_TEST_FN func, _In_ PCSTR name, UINT32 weight );
 
 VOID
 rnddRegisterInitFunction( RNDD_TEST_FN func );

--- a/unittest/inc/rsa32_implementations.h
+++ b/unittest/inc/rsa32_implementations.h
@@ -80,12 +80,12 @@ extern "C" {
 //
 class ImpRsa32{
 public:
-    static char * name;
+    static const char * name;
 };
 
 class ImpRsa32b{
 public:
-    static char * name;
+    static const char * name;
 };
 
 

--- a/unittest/inc/sc_implementations.h
+++ b/unittest/inc/sc_implementations.h
@@ -15,7 +15,7 @@ typedef SYMCRYPT_MARVIN32_EXPANDED_SEED SYMCRYPT_MARVIN32_EXPANDED_KEY, *PSYMCRY
 
 class ImpSc{
 public:
-    static char * name;
+    static const char * name;
 };
 
 //

--- a/unittest/lib/capi_imp_blockcipherpattern.cpp
+++ b/unittest/lib/capi_imp_blockcipherpattern.cpp
@@ -4,6 +4,9 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
+template<>
+ULONG BlockCipherImpState<ImpXxx,AlgXxx,ModeXxx>::calg[CAPI_CALG_ARRAY_SIZE] {};
+
 //
 // Perf Invariant: buf 1 contains the key handle
 //
@@ -78,8 +81,7 @@ algImpDecryptPerfFunction<ImpXxx, AlgXxx, ModeXxx>(PBYTE buf1, PBYTE buf2, PBYTE
     CHECK( CryptDecrypt( *(HCRYPTKEY*) buf1, 0, FALSE, 0, buf3, &len ), "Decryption failure" );
 }
 
-
-
+template<>
 BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::BlockCipherImp()
 {
     state.hKey = 0;
@@ -102,13 +104,13 @@ BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::~BlockCipherImp()
     }
 }
 
+template<>
 SIZE_T BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::coreBlockLen()
 {
     return SYMCRYPT_XXX_BLOCK_SIZE;
 }
 
-ULONG BlockCipherImpState<ImpXxx,AlgXxx,ModeXxx>::calg[CAPI_CALG_ARRAY_SIZE];
-
+template<>
 NTSTATUS 
 BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::setKey( _In_reads_( cbKey ) PCBYTE pbKey, SIZE_T cbKey )
 {
@@ -156,6 +158,7 @@ BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::setKey( _In_reads_( cbKey ) PCBYTE pbKe
     return STATUS_SUCCESS;
 }
 
+template<>
 VOID BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::encrypt( 
         _Inout_updates_opt_( cbChain )   PBYTE pbChain, 
                                         SIZE_T cbChain, 
@@ -249,6 +252,7 @@ VOID BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::encrypt(
     }
 }
 
+template<>
 VOID BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::decrypt( 
         _Inout_updates_opt_( cbChain )   PBYTE pbChain, 
                                         SIZE_T cbChain, 

--- a/unittest/lib/capi_imp_hashpattern.cpp
+++ b/unittest/lib/capi_imp_hashpattern.cpp
@@ -4,23 +4,13 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
-HashImp<ImpXxx, AlgXxx>::HashImp()
-{
-    state.hHash = 0;
-    m_perfDataFunction = &algImpDataPerfFunction<ImpXxx, AlgXxx>;
-}
-
 template<>
-HashImp<ImpXxx, AlgXxx>::~HashImp()
-{
-    CHECK( state.hHash == 0, "Handle leak" );
-}
-
 SIZE_T HashImp<ImpXxx, AlgXxx>::inputBlockLen()
 {
     return SYMCRYPT_XXX_INPUT_BLOCK_SIZE;
 }
 
+template<>
 SIZE_T HashImp<ImpXxx, AlgXxx>::resultLen()
 {
     HCRYPTHASH h;
@@ -37,17 +27,20 @@ SIZE_T HashImp<ImpXxx, AlgXxx>::resultLen()
 
 
 
+template<>
 VOID HashImp<ImpXxx, AlgXxx>::init()
 {
     CHECK( state.hHash == 0, "Handle leak" );
     CHECK( CryptCreateHash( g_capiProvider, CAPI_CALG( ALG_NAME ), 0, 0, &state.hHash ), "error create CAPI" STRING( ALG_Name ) );
 }
 
+template<>
 VOID HashImp<ImpXxx, AlgXxx>::append( _In_reads_( cbData ) PCBYTE pbData, SIZE_T cbData )
 {
     CryptHashData( state.hHash, (PBYTE) pbData, (ULONG) cbData, 0 );
 }
 
+template<>
 VOID HashImp<ImpXxx, AlgXxx>::result( _Out_writes_( cbResult ) PBYTE pbResult, SIZE_T cbResult )
 {
     DWORD resLen = (DWORD) cbResult;
@@ -57,6 +50,7 @@ VOID HashImp<ImpXxx, AlgXxx>::result( _Out_writes_( cbResult ) PBYTE pbResult, S
     state.hHash = 0;
 }
 
+template<>
 NTSTATUS HashImp<ImpXxx, AlgXxx>::initWithLongMessage( ULONGLONG nBytes )
 {
     UNREFERENCED_PARAMETER( nBytes );
@@ -64,7 +58,8 @@ NTSTATUS HashImp<ImpXxx, AlgXxx>::initWithLongMessage( ULONGLONG nBytes )
     return STATUS_NOT_SUPPORTED;
 }
 
-VOID HashImp<ImpXxx, AlgXxx>::hash( 
+template<>
+VOID HashImp<ImpXxx, AlgXxx>::hash(
         _In_reads_( cbData )       PCBYTE pbData, 
                                     SIZE_T cbData, 
         _Out_writes_( cbResult )    PBYTE pbResult, 
@@ -73,6 +68,7 @@ VOID HashImp<ImpXxx, AlgXxx>::hash(
     HashImplementation::hash( pbData, cbData, pbResult, cbResult );
 }
 
+template<>
 NTSTATUS HashImp<ImpXxx,AlgXxx>::exportSymCryptFormat( PBYTE pbResult, SIZE_T cbResultBufferSize, SIZE_T * pcbResult )
 {
     UNREFERENCED_PARAMETER( pbResult );
@@ -82,7 +78,8 @@ NTSTATUS HashImp<ImpXxx,AlgXxx>::exportSymCryptFormat( PBYTE pbResult, SIZE_T cb
     return STATUS_NOT_SUPPORTED;
 }
 
-VOID 
+template<>
+VOID
 algImpDataPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T dataSize )
 {
     UNREFERENCED_PARAMETER( buf3 );
@@ -93,4 +90,17 @@ algImpDataPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_
     CHECK( CryptHashData( h, buf1, (ULONG) dataSize, 0 ), "" );
     CHECK( CryptGetHashParam( h, HP_HASHVAL, buf2, &reslen, 0 ), "" );
     CHECK( CryptDestroyHash( h ), "" );
+}
+
+template<>
+HashImp<ImpXxx, AlgXxx>::HashImp()
+{
+    state.hHash = 0;
+    m_perfDataFunction = &algImpDataPerfFunction<ImpXxx, AlgXxx>;
+}
+
+template<>
+HashImp<ImpXxx, AlgXxx>::~HashImp()
+{
+    CHECK( state.hHash == 0, "Handle leak" );
 }

--- a/unittest/lib/capi_imp_macpattern.cpp
+++ b/unittest/lib/capi_imp_macpattern.cpp
@@ -4,34 +4,19 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
-MacImp<ImpXxx, AlgXxx>::MacImp()
-{
-    state.hHash = 0;
-    state.hKey = 0;
-    m_perfDataFunction = &algImpDataPerfFunction <ImpXxx, AlgXxx>;
-    m_perfKeyFunction  = &algImpKeyPerfFunction  <ImpXxx, AlgXxx>;
-    m_perfCleanFunction= &algImpCleanPerfFunction<ImpXxx, AlgXxx>;
-}
-
 template<>
-MacImp<ImpXxx, AlgXxx>::~MacImp()
-{
-    CHECK( state.hKey == 0, "Handle leak" );
-    CHECK( state.hHash == 0, "Handle leak" );
-}
-
 SIZE_T MacImp<ImpXxx, AlgXxx>::inputBlockLen()
 {
     return SYMCRYPT_XXX_INPUT_BLOCK_SIZE;
 }
 
+template<>
 SIZE_T MacImp<ImpXxx, AlgXxx>::resultLen()
 {
     return SYMCRYPT_XXX_RESULT_SIZE;
 }
 
-
-
+template<>
 NTSTATUS 
 MacImp<ImpXxx, AlgXxx>::init( _In_reads_( cbKey ) PCBYTE pbKey, SIZE_T cbKey )
 {
@@ -69,11 +54,13 @@ MacImp<ImpXxx, AlgXxx>::init( _In_reads_( cbKey ) PCBYTE pbKey, SIZE_T cbKey )
     return STATUS_SUCCESS;
 }
 
+template<>
 VOID MacImp<ImpXxx, AlgXxx>::append( _In_reads_( cbData ) PCBYTE pbData, SIZE_T cbData )
 {
     CryptHashData( state.hHash, (PBYTE) pbData, (ULONG) cbData, 0 );
 }
 
+template<>
 VOID MacImp<ImpXxx, AlgXxx>::result( _Out_writes_( cbResult ) PBYTE pbResult, SIZE_T cbResult )
 {
     DWORD resLen = (DWORD) cbResult;
@@ -86,6 +73,7 @@ VOID MacImp<ImpXxx, AlgXxx>::result( _Out_writes_( cbResult ) PBYTE pbResult, SI
 }
 
 
+template<>
 NTSTATUS
 MacImp<ImpXxx, AlgXxx>::mac( 
     _In_reads_( cbKey )      PCBYTE pbKey,   SIZE_T cbKey, 
@@ -99,6 +87,7 @@ MacImp<ImpXxx, AlgXxx>::mac(
 //
 // Perf Invariant: buf 1 contains the key handle
 //
+template<>
 VOID
 algImpKeyPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T keySize )
 {
@@ -130,6 +119,7 @@ algImpKeyPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T
     
 }
 
+template<>
 VOID
 algImpCleanPerfFunction<ImpXxx, AlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3 )
 {
@@ -139,6 +129,7 @@ algImpCleanPerfFunction<ImpXxx, AlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3 )
     CHECK( CryptDestroyKey( *(HCRYPTKEY *) buf1 ), "" );
 }
 
+template<>
 VOID 
 algImpDataPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T dataSize )
 {
@@ -156,3 +147,19 @@ algImpDataPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_
     CHECK( CryptDestroyHash( h ), "" );
 }
 
+template<>
+MacImp<ImpXxx, AlgXxx>::MacImp()
+{
+    state.hHash = 0;
+    state.hKey = 0;
+    m_perfDataFunction = &algImpDataPerfFunction <ImpXxx, AlgXxx>;
+    m_perfKeyFunction  = &algImpKeyPerfFunction  <ImpXxx, AlgXxx>;
+    m_perfCleanFunction= &algImpCleanPerfFunction<ImpXxx, AlgXxx>;
+}
+
+template<>
+MacImp<ImpXxx, AlgXxx>::~MacImp()
+{
+    CHECK( state.hKey == 0, "Handle leak" );
+    CHECK( state.hHash == 0, "Handle leak" );
+}

--- a/unittest/lib/capi_implementations.cpp
+++ b/unittest/lib/capi_implementations.cpp
@@ -10,7 +10,7 @@
 
 HCRYPTPROV g_capiProvider;
 
-char * ImpCapi::name = "Capi";
+const char * ImpCapi::name = "Capi";
 
 #define CAPI_CALG( x )   CONCAT2( CALG_, x )
 
@@ -388,7 +388,7 @@ algImpCleanPerfFunction<ImpCapi,AlgRc4>( PBYTE buf1, PBYTE buf2, PBYTE buf3 )
     CHECK( CryptDestroyKey( *(HCRYPTKEY *) buf1 ), "Failed to destroy key" );
 }
 
-
+template<>
 StreamCipherImp<ImpCapi, AlgRc4>::StreamCipherImp()
 {
     state.hKey = 0;

--- a/unittest/lib/cng_imp_authenc.cpp
+++ b/unittest/lib/cng_imp_authenc.cpp
@@ -4,7 +4,8 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
-BCRYPT_ALG_HANDLE AuthEncImpState<ImpXxx, AlgXxx, ModeXxx>::hAlg;
+template<>
+BCRYPT_ALG_HANDLE AuthEncImpState<ImpXxx, AlgXxx, ModeXxx>::hAlg {};
 
 template<>
 VOID 

--- a/unittest/lib/cng_imp_blockcipherpattern.cpp
+++ b/unittest/lib/cng_imp_blockcipherpattern.cpp
@@ -4,7 +4,8 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
-BCRYPT_ALG_HANDLE BlockCipherImpState<ImpXxx, AlgXxx, ModeXxx>::hAlg;
+template<>
+BCRYPT_ALG_HANDLE BlockCipherImpState<ImpXxx, AlgXxx, ModeXxx>::hAlg {};
 
 template<>
 VOID 
@@ -93,6 +94,7 @@ BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::~BlockCipherImp()
     state.hAlg = 0;
 }
 
+template<>
 SIZE_T BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::coreBlockLen()
 {
     ULONG   len;
@@ -105,6 +107,7 @@ SIZE_T BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::coreBlockLen()
     return len;
 }
 
+template<>
 NTSTATUS BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::setKey( _In_reads_( cbKey ) PCBYTE pbKey, SIZE_T cbKey )
 {
     NTSTATUS status = STATUS_SUCCESS;
@@ -220,7 +223,7 @@ Cleanup:
     
 }
 
-
+template<>
 VOID
 BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::encrypt( 
         _Inout_updates_opt_( cbChain )   PBYTE pbChain, 
@@ -241,6 +244,7 @@ BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::encrypt(
     CHECK( res == cbData, "?" );
 }
 
+template<>
 VOID
 BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::decrypt( 
         _Inout_updates_opt_( cbChain )   PBYTE pbChain, 

--- a/unittest/lib/cng_imp_hashpattern.cpp
+++ b/unittest/lib/cng_imp_hashpattern.cpp
@@ -4,28 +4,10 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
-BCRYPT_ALG_HANDLE HashImpState<ImpXxx, AlgXxx>::hAlg;
-
-
-HashImp<ImpXxx, AlgXxx>::HashImp()
-{
-    CHECK( CngOpenAlgorithmProviderFn( &state.hAlg, LSTRING( ALG_NAME ), NULL, bcoapReusableFlag() ) == STATUS_SUCCESS, 
-        "Could not open CNG/" STRING( ALG_Name ) );
-    state.hHash = 0;
-    m_perfDataFunction = &algImpDataPerfFunction<ImpXxx, AlgXxx>;
-    m_perfKeyFunction = &algImpKeyPerfFunction<ImpXxx, AlgXxx>;
-    m_perfCleanFunction = &algImpCleanPerfFunction<ImpXxx, AlgXxx>;
-}
+template<>
+BCRYPT_ALG_HANDLE HashImpState<ImpXxx, AlgXxx>::hAlg {};
 
 template<>
-HashImp<ImpXxx, AlgXxx>::~HashImp()
-{
-    CHECK( state.hHash == 0, "Handle leak" );
-    
-    CHECK( NT_SUCCESS( CngCloseAlgorithmProviderFn( state.hAlg, 0 )), "Could not close CNG/" STRING( ALG_Name ) );
-    state.hAlg = 0;
-}
-
 SIZE_T HashImp<ImpXxx, AlgXxx>::inputBlockLen()
 {
     ULONG   len;
@@ -36,6 +18,7 @@ SIZE_T HashImp<ImpXxx, AlgXxx>::inputBlockLen()
     return len;
 }
 
+template<>
 SIZE_T HashImp<ImpXxx, AlgXxx>::resultLen()
 {
     ULONG   len;
@@ -46,7 +29,7 @@ SIZE_T HashImp<ImpXxx, AlgXxx>::resultLen()
     return len;
 }
 
-
+template<>
 VOID HashImp<ImpXxx, AlgXxx>::init()
 {
     CHECK( state.hHash == 0, "Handle leak");
@@ -60,12 +43,14 @@ VOID HashImp<ImpXxx, AlgXxx>::init()
             "Error creating hash CNG/" STRING( ALG_Name ) );
 }
 
+template<>
 VOID HashImp<ImpXxx, AlgXxx>::append( _In_reads_( cbData ) PCBYTE pbData, SIZE_T cbData )
 {
     CHECK( NT_SUCCESS( CngHashDataFn( state.hHash, (PBYTE) pbData, (ULONG) cbData, 0 ) ),
         "Error hashing CNG/" STRING( ALG_Name ) );
 }
 
+template<>
 VOID HashImp<ImpXxx, AlgXxx>::result( _Out_writes_( cbResult ) PBYTE pbResult, SIZE_T cbResult )
 {
     CHECK( NT_SUCCESS( CngFinishHashFn( state.hHash, pbResult, (ULONG) cbResult, 0 ) ),
@@ -75,6 +60,7 @@ VOID HashImp<ImpXxx, AlgXxx>::result( _Out_writes_( cbResult ) PBYTE pbResult, S
 }
 
 /*
+template<>
 VOID HashImp<ImpXxx, AlgXxx>::hash( PCBYTE pbData, SIZE_T cbData, PBYTE pbResult, SIZE_T cbResult )
 {
     BYTE buf[384];
@@ -87,6 +73,7 @@ VOID HashImp<ImpXxx, AlgXxx>::hash( PCBYTE pbData, SIZE_T cbData, PBYTE pbResult
 }
 */
 
+template<>
 NTSTATUS HashImp<ImpXxx, AlgXxx>::initWithLongMessage( ULONGLONG nBytes )
 {
     UNREFERENCED_PARAMETER( nBytes );
@@ -94,6 +81,7 @@ NTSTATUS HashImp<ImpXxx, AlgXxx>::initWithLongMessage( ULONGLONG nBytes )
     return STATUS_NOT_SUPPORTED;
 }
 
+template<>
 NTSTATUS HashImp<ImpXxx,AlgXxx>::exportSymCryptFormat( PBYTE pbResult, SIZE_T cbResultBufferSize, SIZE_T * pcbResult )
 {
     UNREFERENCED_PARAMETER( pbResult );
@@ -103,6 +91,7 @@ NTSTATUS HashImp<ImpXxx,AlgXxx>::exportSymCryptFormat( PBYTE pbResult, SIZE_T cb
     return STATUS_NOT_SUPPORTED;
 }
 
+template<>
 VOID HashImp<ImpXxx, AlgXxx>::hash( 
         _In_reads_( cbData )       PCBYTE pbData, 
                                     SIZE_T cbData, 
@@ -124,6 +113,7 @@ VOID HashImp<ImpXxx, AlgXxx>::hash(
 // To measure the cost of the setup separately, we pretend to use a key as that matches the perf infrastructure.
 //
 
+template<>
 VOID 
 algImpKeyPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T keySize )
 {
@@ -144,6 +134,7 @@ algImpKeyPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T
     }
 }
 
+template<>
 VOID
 algImpCleanPerfFunction<ImpXxx, AlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3 )
 {
@@ -157,6 +148,7 @@ algImpCleanPerfFunction<ImpXxx, AlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3 )
     }
 }
 
+template<>
 VOID 
 algImpDataPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T dataSize )
 {
@@ -177,5 +169,25 @@ algImpDataPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_
         CHECK( NT_SUCCESS(CngFinishHashFn( h, buf3, (ULONG)(SYMCRYPT_XXX_RESULT_SIZE), 0 )), "" );
         CHECK( NT_SUCCESS(CngDestroyHashFn( h )), "" );
     }
+}
+
+template<>
+HashImp<ImpXxx, AlgXxx>::HashImp()
+{
+    CHECK( CngOpenAlgorithmProviderFn( &state.hAlg, LSTRING( ALG_NAME ), NULL, bcoapReusableFlag() ) == STATUS_SUCCESS,
+           "Could not open CNG/" STRING( ALG_Name ) );
+    state.hHash = 0;
+    m_perfDataFunction = &algImpDataPerfFunction<ImpXxx, AlgXxx>;
+    m_perfKeyFunction = &algImpKeyPerfFunction<ImpXxx, AlgXxx>;
+    m_perfCleanFunction = &algImpCleanPerfFunction<ImpXxx, AlgXxx>;
+}
+
+template<>
+HashImp<ImpXxx, AlgXxx>::~HashImp()
+{
+    CHECK( state.hHash == 0, "Handle leak" );
+
+    CHECK( NT_SUCCESS( CngCloseAlgorithmProviderFn( state.hAlg, 0 )), "Could not close CNG/" STRING( ALG_Name ) );
+    state.hAlg = 0;
 }
 

--- a/unittest/lib/cng_imp_kdfpattern.cpp
+++ b/unittest/lib/cng_imp_kdfpattern.cpp
@@ -4,34 +4,10 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
-BCRYPT_ALG_HANDLE KdfImpState<ImpXxx, AlgXxx, BaseAlgXxx>::hAlg;
-
-//
-// Empty constructor. 
-//
 template<>
-KdfImp<ImpXxx, AlgXxx, BaseAlgXxx>::KdfImp()
-{
-    CHECK( CngOpenAlgorithmProviderFn( &state.hAlg, PROVIDER_NAME( ALG_NAME ), NULL, 0 ) == STATUS_SUCCESS, 
-        "Could not open CNG/" STRING( ALG_Name ) );
-
-    CHECK3( CngOpenAlgorithmProviderFn( &state.hBaseAlg, CNG_XXX_HASH_ALG_NAMEU, NULL, BCRYPT_ALG_HANDLE_HMAC_FLAG  ) == STATUS_SUCCESS, 
-        "Could not open CNG/%s", CNG_XXX_HASH_ALG_NAMEU );
-
-    m_perfDataFunction = &algImpDataPerfFunction <ImpXxx, AlgXxx, BaseAlgXxx>;
-    m_perfKeyFunction  = &algImpKeyPerfFunction  <ImpXxx, AlgXxx, BaseAlgXxx>;
-    m_perfCleanFunction= &algImpCleanPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>;
-}
+BCRYPT_ALG_HANDLE KdfImpState<ImpXxx, AlgXxx, BaseAlgXxx>::hAlg {};
 
 template<>
-KdfImp<ImpXxx, AlgXxx, BaseAlgXxx>::~KdfImp()
-{
-    CHECK3( NT_SUCCESS( CngCloseAlgorithmProviderFn( state.hAlg    , 0 )), "Could not close CNG/%s", STRING( ALG_Name ) );
-    CHECK3( NT_SUCCESS( CngCloseAlgorithmProviderFn( state.hBaseAlg, 0 )), "Could not close CNG/%s", CNG_XXX_HASH_ALG_NAMEU );
-    state.hAlg = 0;
-}
-
-
 VOID 
 algImpKeyPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T keySize )
 {
@@ -50,6 +26,7 @@ algImpKeyPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE
     *(BCRYPT_KEY_HANDLE *) buf1 = hKey;
 }
 
+template<>
 VOID 
 algImpCleanPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3 )
 {
@@ -59,4 +36,27 @@ algImpCleanPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>( PBYTE buf1, PBYTE buf2, PBY
     CHECK( NT_SUCCESS( CngDestroyKeyFn( *(BCRYPT_KEY_HANDLE *) buf1 ) ), "?" );
 }
 
+//
+// Empty constructor.
+//
+template<>
+KdfImp<ImpXxx, AlgXxx, BaseAlgXxx>::KdfImp()
+{
+    CHECK( CngOpenAlgorithmProviderFn( &state.hAlg, PROVIDER_NAME( ALG_NAME ), NULL, 0 ) == STATUS_SUCCESS,
+           "Could not open CNG/" STRING( ALG_Name ) );
 
+    CHECK3( CngOpenAlgorithmProviderFn( &state.hBaseAlg, CNG_XXX_HASH_ALG_NAMEU, NULL, BCRYPT_ALG_HANDLE_HMAC_FLAG  ) == STATUS_SUCCESS,
+            "Could not open CNG/%s", CNG_XXX_HASH_ALG_NAMEU );
+
+    m_perfDataFunction = &algImpDataPerfFunction <ImpXxx, AlgXxx, BaseAlgXxx>;
+    m_perfKeyFunction  = &algImpKeyPerfFunction  <ImpXxx, AlgXxx, BaseAlgXxx>;
+    m_perfCleanFunction= &algImpCleanPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>;
+}
+
+template<>
+KdfImp<ImpXxx, AlgXxx, BaseAlgXxx>::~KdfImp()
+{
+    CHECK3( NT_SUCCESS( CngCloseAlgorithmProviderFn( state.hAlg    , 0 )), "Could not close CNG/%s", STRING( ALG_Name ) );
+    CHECK3( NT_SUCCESS( CngCloseAlgorithmProviderFn( state.hBaseAlg, 0 )), "Could not close CNG/%s", CNG_XXX_HASH_ALG_NAMEU );
+    state.hAlg = 0;
+}

--- a/unittest/lib/cng_imp_macpattern.cpp
+++ b/unittest/lib/cng_imp_macpattern.cpp
@@ -4,9 +4,136 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
-BCRYPT_ALG_HANDLE MacImpState<ImpXxx, AlgXxx>::hAlg;
+template<>
+BCRYPT_ALG_HANDLE MacImpState<ImpXxx, AlgXxx>::hAlg {};
+
+template<>
+SIZE_T MacImp<ImpXxx, AlgXxx>::inputBlockLen()
+{
+    ULONG   len;
+    ULONG   res;
+    CHECK( NT_SUCCESS( CngGetPropertyFn( state.hAlg, BCRYPT_HASH_BLOCK_LENGTH, (PBYTE) &len, sizeof( len ), &res, 0 ) ),
+        "Could not query input size CNG/" STRING( ALG_Name ) );
+    CHECK( res == sizeof( len ), "??" );
+    return len;
+}
+
+template<>
+SIZE_T MacImp<ImpXxx, AlgXxx>::resultLen()
+{
+    ULONG   len;
+    ULONG   res;
+    CHECK( NT_SUCCESS( CngGetPropertyFn( state.hAlg, BCRYPT_HASH_LENGTH, (PBYTE) &len, sizeof( len ), &res, 0 ) ),
+        "Could not query hash size CNG/" STRING( ALG_Name ) );
+    CHECK( res == sizeof( len ), "??" );
+    return len;
+}
+
+template<>
+NTSTATUS MacImp<ImpXxx, AlgXxx>::init( _In_reads_( cbKey ) PCBYTE pbKey, SIZE_T cbKey )
+{
+    CHECK( state.hHash == 0, "Hash already exists CNG/" STRING( ALG_Name ) );
+    CHECK( NT_SUCCESS( CngCreateHashFn(     state.hAlg, 
+                                            &state.hHash, 
+                                            state.hashObjectBuffer,
+                                            sizeof( state.hashObjectBuffer ),
+                                            (PBYTE) pbKey,
+                                            (ULONG) cbKey,
+                                            0) ),
+            "Error creating hash CNG/" STRING( ALG_Name ) );
+    
+    return STATUS_SUCCESS;
+}
+
+template<>
+VOID MacImp<ImpXxx, AlgXxx>::append( _In_reads_( cbData ) PCBYTE pbData, SIZE_T cbData )
+{
+    CHECK( NT_SUCCESS( CngHashDataFn( state.hHash, (PBYTE) pbData, (ULONG) cbData, 0 ) ),
+        "Error hashing CNG/" STRING( ALG_Name ) );
+}
+
+template<>
+VOID MacImp<ImpXxx, AlgXxx>::result( _Out_writes_( cbResult ) PBYTE pbResult, SIZE_T cbResult )
+{
+    CHECK( NT_SUCCESS( CngFinishHashFn( state.hHash, pbResult, (ULONG) cbResult, 0 ) ),
+        "Error finalizing CNG/" STRING( ALG_Name ) );
+    CHECK( NT_SUCCESS( CngDestroyHashFn( state.hHash ) ), "Error destoring CNG/" STRING( ALG_Name ) );
+    state.hHash = 0;
+}
+
+template<>
+NTSTATUS
+MacImp<ImpXxx, AlgXxx>::mac( 
+    _In_reads_( cbKey )      PCBYTE pbKey,   SIZE_T cbKey, 
+    _In_reads_( cbData )     PCBYTE pbData,  SIZE_T cbData, 
+    _Out_writes_( cbResult )  PBYTE pbResult, SIZE_T cbResult )
+{
+    return MacImplementation::mac( pbKey, cbKey, pbData, cbData, pbResult, cbResult );
+}
 
 
+//
+// Performance is a bit strange.
+// On Win8 & beyond we can use re-usable hash objects to move the key expansion to the keying phase.
+// On Win7 and earlier this doesn't work. Our perf functions adapt, this adds a very small additional overhead,
+// but that is very minor compared to the actual work, and gives a much better representation of the actual
+// cost of each computation.
+//
+
+template<>
+VOID 
+algImpKeyPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T keySize )
+{
+    UNREFERENCED_PARAMETER( buf2 );
+
+    //
+    // On Win8 & beyond we can pre-expand
+    //
+    if( g_osVersion >= 0x0602 )
+    {
+        CHECK( NT_SUCCESS(CngCreateHashFn( MacImpState<ImpXxx, AlgXxx>::hAlg, (BCRYPT_HASH_HANDLE *)buf1, buf1 + 16, PERF_BUFFER_SIZE - 16, buf3, (ULONG)keySize, 0 )), "" );
+    } else {
+            //
+            // All we can do is save the key size
+            //
+            *(SIZE_T *) buf1 = keySize;
+    }
+}
+
+template<>
+VOID
+algImpCleanPerfFunction<ImpXxx, AlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3 )
+{
+    UNREFERENCED_PARAMETER( buf2 );
+    UNREFERENCED_PARAMETER( buf3 );
+
+    if( g_osVersion >= 0x0602 )
+    {
+        CHECK( NT_SUCCESS(CngDestroyHashFn( *(BCRYPT_HASH_HANDLE *) buf1 )), "" );
+    }
+}
+
+template<>
+VOID 
+algImpDataPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T dataSize )
+{
+    BCRYPT_HASH_HANDLE h;
+
+    if( g_osVersion >= 0x0602 )
+    {
+        h = *(BCRYPT_HASH_HANDLE *) buf1;
+        CHECK( NT_SUCCESS(CngHashDataFn  ( h, buf2, (ULONG) dataSize, 0 )), "" );
+        CHECK( NT_SUCCESS(CngFinishHashFn( h, buf3, (ULONG)(SYMCRYPT_XXX_RESULT_SIZE), 0 )), "" );
+    } else {
+        CHECK( NT_SUCCESS(CngCreateHashFn( MacImpState<ImpXxx, AlgXxx>::hAlg, &h, buf1 + 16, PERF_BUFFER_SIZE, buf3, (ULONG)*(SIZE_T *)buf1, 0 )), "" );
+        CHECK( NT_SUCCESS(CngHashDataFn  ( h, buf2, (ULONG) dataSize, 0 )), "" );
+        CHECK( NT_SUCCESS(CngFinishHashFn( h, buf3, (ULONG)(SYMCRYPT_XXX_RESULT_SIZE), 0 )), "" );
+        CHECK( NT_SUCCESS(CngDestroyHashFn( h )), "" );
+    }
+}
+
+
+template<>
 MacImp<ImpXxx, AlgXxx>::MacImp()
 {
     NTSTATUS status;
@@ -37,122 +164,3 @@ MacImp<ImpXxx, AlgXxx>::~MacImp()
     CHECK( NT_SUCCESS( CngCloseAlgorithmProviderFn( state.hAlg, 0 )), "Could not close CNG/" STRING( ALG_Name ) );
     state.hAlg = 0;
 }
-
-SIZE_T MacImp<ImpXxx, AlgXxx>::inputBlockLen()
-{
-    ULONG   len;
-    ULONG   res;
-    CHECK( NT_SUCCESS( CngGetPropertyFn( state.hAlg, BCRYPT_HASH_BLOCK_LENGTH, (PBYTE) &len, sizeof( len ), &res, 0 ) ),
-        "Could not query input size CNG/" STRING( ALG_Name ) );
-    CHECK( res == sizeof( len ), "??" );
-    return len;
-}
-
-SIZE_T MacImp<ImpXxx, AlgXxx>::resultLen()
-{
-    ULONG   len;
-    ULONG   res;
-    CHECK( NT_SUCCESS( CngGetPropertyFn( state.hAlg, BCRYPT_HASH_LENGTH, (PBYTE) &len, sizeof( len ), &res, 0 ) ),
-        "Could not query hash size CNG/" STRING( ALG_Name ) );
-    CHECK( res == sizeof( len ), "??" );
-    return len;
-}
-
-
-NTSTATUS MacImp<ImpXxx, AlgXxx>::init( _In_reads_( cbKey ) PCBYTE pbKey, SIZE_T cbKey )
-{
-    CHECK( state.hHash == 0, "Hash already exists CNG/" STRING( ALG_Name ) );
-    CHECK( NT_SUCCESS( CngCreateHashFn(     state.hAlg, 
-                                            &state.hHash, 
-                                            state.hashObjectBuffer,
-                                            sizeof( state.hashObjectBuffer ),
-                                            (PBYTE) pbKey,
-                                            (ULONG) cbKey,
-                                            0) ),
-            "Error creating hash CNG/" STRING( ALG_Name ) );
-    
-    return STATUS_SUCCESS;
-}
-
-VOID MacImp<ImpXxx, AlgXxx>::append( _In_reads_( cbData ) PCBYTE pbData, SIZE_T cbData )
-{
-    CHECK( NT_SUCCESS( CngHashDataFn( state.hHash, (PBYTE) pbData, (ULONG) cbData, 0 ) ),
-        "Error hashing CNG/" STRING( ALG_Name ) );
-}
-
-VOID MacImp<ImpXxx, AlgXxx>::result( _Out_writes_( cbResult ) PBYTE pbResult, SIZE_T cbResult )
-{
-    CHECK( NT_SUCCESS( CngFinishHashFn( state.hHash, pbResult, (ULONG) cbResult, 0 ) ),
-        "Error finalizing CNG/" STRING( ALG_Name ) );
-    CHECK( NT_SUCCESS( CngDestroyHashFn( state.hHash ) ), "Error destoring CNG/" STRING( ALG_Name ) );
-    state.hHash = 0;
-}
-
-NTSTATUS
-MacImp<ImpXxx, AlgXxx>::mac( 
-    _In_reads_( cbKey )      PCBYTE pbKey,   SIZE_T cbKey, 
-    _In_reads_( cbData )     PCBYTE pbData,  SIZE_T cbData, 
-    _Out_writes_( cbResult )  PBYTE pbResult, SIZE_T cbResult )
-{
-    return MacImplementation::mac( pbKey, cbKey, pbData, cbData, pbResult, cbResult );
-}
-
-
-//
-// Performance is a bit strange.
-// On Win8 & beyond we can use re-usable hash objects to move the key expansion to the keying phase.
-// On Win7 and earlier this doesn't work. Our perf functions adapt, this adds a very small additional overhead,
-// but that is very minor compared to the actual work, and gives a much better representation of the actual
-// cost of each computation.
-//
-
-VOID 
-algImpKeyPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T keySize )
-{
-    UNREFERENCED_PARAMETER( buf2 );
-
-    //
-    // On Win8 & beyond we can pre-expand
-    //
-    if( g_osVersion >= 0x0602 )
-    {
-        CHECK( NT_SUCCESS(CngCreateHashFn( MacImpState<ImpXxx, AlgXxx>::hAlg, (BCRYPT_HASH_HANDLE *)buf1, buf1 + 16, PERF_BUFFER_SIZE - 16, buf3, (ULONG)keySize, 0 )), "" );
-    } else {
-            //
-            // All we can do is save the key size
-            //
-            *(SIZE_T *) buf1 = keySize;
-    }
-}
-
-VOID
-algImpCleanPerfFunction<ImpXxx, AlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3 )
-{
-    UNREFERENCED_PARAMETER( buf2 );
-    UNREFERENCED_PARAMETER( buf3 );
-
-    if( g_osVersion >= 0x0602 )
-    {
-        CHECK( NT_SUCCESS(CngDestroyHashFn( *(BCRYPT_HASH_HANDLE *) buf1 )), "" );
-    }
-}
-
-VOID 
-algImpDataPerfFunction<ImpXxx, AlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T dataSize )
-{
-    BCRYPT_HASH_HANDLE h;
-
-    if( g_osVersion >= 0x0602 )
-    {
-        h = *(BCRYPT_HASH_HANDLE *) buf1;
-        CHECK( NT_SUCCESS(CngHashDataFn  ( h, buf2, (ULONG) dataSize, 0 )), "" );
-        CHECK( NT_SUCCESS(CngFinishHashFn( h, buf3, (ULONG)(SYMCRYPT_XXX_RESULT_SIZE), 0 )), "" );
-    } else {
-        CHECK( NT_SUCCESS(CngCreateHashFn( MacImpState<ImpXxx, AlgXxx>::hAlg, &h, buf1 + 16, PERF_BUFFER_SIZE, buf3, (ULONG)*(SIZE_T *)buf1, 0 )), "" );
-        CHECK( NT_SUCCESS(CngHashDataFn  ( h, buf2, (ULONG) dataSize, 0 )), "" );
-        CHECK( NT_SUCCESS(CngFinishHashFn( h, buf3, (ULONG)(SYMCRYPT_XXX_RESULT_SIZE), 0 )), "" );
-        CHECK( NT_SUCCESS(CngDestroyHashFn( h )), "" );
-    }
-}
-
-

--- a/unittest/lib/cng_imp_pbkdf2pattern.cpp
+++ b/unittest/lib/cng_imp_pbkdf2pattern.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
+template<>
 VOID
 KdfImp<ImpXxx,AlgPbkdf2,BaseAlgXxx>::derive(
         _In_reads_( cbKey )     PCBYTE          pbKey,
@@ -67,6 +68,7 @@ KdfImp<ImpXxx,AlgPbkdf2,BaseAlgXxx>::derive(
 
 }
 
+template<>
 VOID
 algImpDataPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T dataSize )
 {

--- a/unittest/lib/cng_imp_sp800_108pattern.cpp
+++ b/unittest/lib/cng_imp_sp800_108pattern.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
+template<>
 VOID
 KdfImp<ImpXxx,AlgSp800_108,BaseAlgXxx>::derive(
         _In_reads_( cbKey )     PCBYTE          pbKey,
@@ -44,6 +45,7 @@ KdfImp<ImpXxx,AlgSp800_108,BaseAlgXxx>::derive(
     CHECK( cbResult == cbDst, "Sp800_108 result size mismatch" );
 }
 
+template<>
 VOID
 algImpDataPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T dataSize )
 {

--- a/unittest/lib/cng_imp_tlsprf1_1pattern.cpp
+++ b/unittest/lib/cng_imp_tlsprf1_1pattern.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
+template<>
 VOID
 KdfImp<ImpCng, AlgTlsPrf1_1, BaseAlgXxx>::derive(
     _In_reads_(cbKey)       PCBYTE          pbKey,
@@ -40,6 +41,7 @@ KdfImp<ImpCng, AlgTlsPrf1_1, BaseAlgXxx>::derive(
     CHECK(cbResult == cbDst, "TLS PRF 1.1 result size mismatch");
 }
 
+template<>
 VOID
 algImpDataPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T dataSize)
 {

--- a/unittest/lib/cng_imp_tlsprf1_2pattern.cpp
+++ b/unittest/lib/cng_imp_tlsprf1_2pattern.cpp
@@ -4,6 +4,7 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
+template<>
 VOID
 KdfImp<ImpCng, AlgTlsPrf1_2, BaseAlgXxx>::derive(
     _In_reads_(cbKey)       PCBYTE          pbKey,
@@ -41,6 +42,7 @@ KdfImp<ImpCng, AlgTlsPrf1_2, BaseAlgXxx>::derive(
     CHECK(cbResult == cbDst, "TLS PRF 1.2 result size mismatch");
 }
 
+template<>
 VOID
 algImpDataPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>(PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T dataSize)
 {

--- a/unittest/lib/cng_implementations.cpp
+++ b/unittest/lib/cng_implementations.cpp
@@ -8,7 +8,7 @@
 
 #if INCLUDE_IMPL_CNG
 
-char * ImpCng::name = "Cng";
+const char * ImpCng::name = "Cng";
 
 #define BCRYPT_CHAIN_MODE_XXX   CONCAT2( BCRYPT_CHAIN_MODE_, ALG_MODE )
 
@@ -466,33 +466,33 @@ cngAesCmac_HmacMode()
 #define ALG_Name    Pbkdf2
 
 #define ALG_Base    HmacMd5
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_pbkdf2pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha1
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_pbkdf2pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha256
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_pbkdf2pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha384
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_pbkdf2pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha512
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_pbkdf2pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    AesCmac
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_pbkdf2pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #undef ALG_NAME
@@ -502,33 +502,33 @@ cngAesCmac_HmacMode()
 #define ALG_Name    Sp800_108
 
 #define ALG_Base    HmacMd5
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_sp800_108pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha1
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_sp800_108pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha256
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_sp800_108pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha384
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_sp800_108pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha512
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_sp800_108pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    AesCmac
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_sp800_108pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #undef ALG_NAME
@@ -538,8 +538,8 @@ cngAesCmac_HmacMode()
 #define ALG_Name    TlsPrf1_1
 
 #define ALG_Base    HmacMd5
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_tlsprf1_1pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #undef ALG_NAME
@@ -549,18 +549,18 @@ cngAesCmac_HmacMode()
 #define ALG_Name    TlsPrf1_2
 
 #define ALG_Base    HmacSha256
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_tlsprf1_2pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha384
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_tlsprf1_2pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha512
-#include "cng_imp_kdfpattern.cpp"
 #include "cng_imp_tlsprf1_2pattern.cpp"
+#include "cng_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #undef ALG_NAME
@@ -602,7 +602,8 @@ AuthEncImp<ImpCng, AlgAes, ModeGcm>::getNonceSizes()
 //////////////////////////
 // RC4
 
-BCRYPT_ALG_HANDLE StreamCipherImpState<ImpCng, AlgRc4>::hAlg;
+template<>
+BCRYPT_ALG_HANDLE StreamCipherImpState<ImpCng, AlgRc4>::hAlg {};
 
 template<>
 VOID
@@ -645,6 +646,7 @@ algImpCleanPerfFunction<ImpCng,AlgRc4>( PBYTE buf1, PBYTE buf2, PBYTE buf3 )
 }
 
 
+template<>
 StreamCipherImp<ImpCng, AlgRc4>::StreamCipherImp()
 {
     CHECK( CngOpenAlgorithmProviderFn( &state.hAlg, PROVIDER_NAME( RC4 ), NULL, 0 ) == STATUS_SUCCESS,
@@ -1363,7 +1365,7 @@ const CNG_HASH_INFO cngHashInfoTable[] = {
     { NULL },
 };
 
-PCCNG_HASH_INFO getHashInfo( PCSTR pcstrName )
+FORCEINLINE PCCNG_HASH_INFO getHashInfo( PCSTR pcstrName )
 {
     for( int i=0; cngHashInfoTable[i].name != NULL; i++ )
     {
@@ -2021,6 +2023,7 @@ RsaEncImp<ImpCng, AlgRsaEncRaw>::setKey( PCRSAKEY_TESTBLOB pcKeyBlob )
     return ntStatus;
 }
 
+template<>
 NTSTATUS
 RsaEncImp<ImpCng, AlgRsaEncRaw>::encrypt(
         _In_reads_( cbMsg )             PCBYTE  pbMsg,
@@ -2060,6 +2063,7 @@ RsaEncImp<ImpCng, AlgRsaEncRaw>::encrypt(
     return ntStatus;
 }
 
+template<>
 NTSTATUS
 RsaEncImp<ImpCng, AlgRsaEncRaw>::decrypt(
         _In_reads_( cbCiphertext )      PCBYTE  pbCiphertext,
@@ -2265,6 +2269,7 @@ RsaEncImp<ImpCng, AlgRsaEncPkcs1>::setKey( PCRSAKEY_TESTBLOB pcKeyBlob )
     return ntStatus;
 }
 
+template<>
 NTSTATUS
 RsaEncImp<ImpCng, AlgRsaEncPkcs1>::encrypt(
         _In_reads_( cbMsg )             PCBYTE  pbMsg,
@@ -2299,6 +2304,7 @@ RsaEncImp<ImpCng, AlgRsaEncPkcs1>::encrypt(
     return ntStatus;
 }
 
+template<>
 NTSTATUS
 RsaEncImp<ImpCng, AlgRsaEncPkcs1>::decrypt(
         _In_reads_( cbCiphertext )      PCBYTE  pbCiphertext,
@@ -2516,6 +2522,7 @@ RsaEncImp<ImpCng, AlgRsaEncOaep>::setKey( PCRSAKEY_TESTBLOB pcKeyBlob )
     return ntStatus;
 }
 
+template<>
 NTSTATUS
 RsaEncImp<ImpCng, AlgRsaEncOaep>::encrypt(
         _In_reads_( cbMsg )             PCBYTE  pbMsg,
@@ -2550,6 +2557,7 @@ RsaEncImp<ImpCng, AlgRsaEncOaep>::encrypt(
     return NT_SUCCESS( ntStatus ) ? STATUS_SUCCESS : STATUS_UNSUCCESSFUL;
 }
 
+template<>
 NTSTATUS
 RsaEncImp<ImpCng, AlgRsaEncOaep>::decrypt(
         _In_reads_( cbCiphertext )      PCBYTE  pbCiphertext,

--- a/unittest/lib/env_SymCryptUnittest.cpp
+++ b/unittest/lib/env_SymCryptUnittest.cpp
@@ -64,7 +64,7 @@ SymCryptInitEnvUnittest( UINT32 version )
     //
     g_SymCryptCpuFeaturesNotPresent |= SYMCRYPT_CPU_FEATURE_AVX2;
 
-    #if SYMCRYPT_MS_VC
+    #if SYMCRYPT_MS_VC || WIN32
         if( (GetEnabledXStateFeatures() & XSTATE_MASK_AVX) != 0 )
         {
             g_SymCryptCpuFeaturesNotPresent &= ~SYMCRYPT_CPU_FEATURE_AVX2;
@@ -90,7 +90,9 @@ SymCryptInitEnvUnittest( UINT32 version )
     SymCryptInitEnvCommon( version );
 }
 
+#ifndef __GNUC__
 _Analysis_noreturn_
+#endif
 VOID
 SYMCRYPT_CALL
 SymCryptFatalEnvUnittest( ULONG fatalCode )

--- a/unittest/lib/kat.cpp
+++ b/unittest/lib/kat.cpp
@@ -28,7 +28,7 @@ String strip( const String & strIn )
 
 
 
-KatData::KatData( _In_ PSTR name, _In_ PCCHAR pbData, SIZE_T cbData )
+KatData::KatData( _In_ PCSTR name, _In_ PCCHAR pbData, SIZE_T cbData )
 {
     m_line = 1;
     m_pbData = pbData;

--- a/unittest/lib/main.cpp
+++ b/unittest/lib/main.cpp
@@ -397,7 +397,7 @@ BOOL setContainsPrefix( const StringSet & set, const std::string & str )
 }
 
 BOOL
-updateNameSet( _In_z_ PCSTR * names, _Inout_ StringSet * set, CHAR op, _In_ PSTR name )
+updateNameSet( _In_z_ PCSTR * names, _Inout_ StringSet * set, CHAR op, _In_ PCSTR name )
 {
     BOOL nameMatch = FALSE;
     SIZE_T nameLen = strlen( name );
@@ -659,7 +659,7 @@ usage()
 
 typedef struct _CPU_FEATURE_DATA
 {
-    PSTR                    name;
+    PCSTR                   name;
     SYMCRYPT_CPU_FEATURES   mask;
 } CPU_FEATURE_DATA;
 
@@ -928,9 +928,9 @@ fatal( _In_ PCSTR file, ULONG line, _In_ PCSTR format, ... )
     exit( -1 );
 }
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
 KatData *
-getCustomResource( _In_ PSTR resourceName, _In_ PSTR resourceType )
+getCustomResource( _In_ PCSTR resourceName, _In_ PCSTR resourceType )
 {
     HRSRC   resourceHandle;
     HGLOBAL resourceDataHandle;
@@ -967,9 +967,11 @@ void getPlatformInformation()
     g_osVersion = (versionInfo.dwMajorVersion << 8) + (versionInfo.dwMinorVersion & 0xff);
 }
 #elif SYMCRYPT_GNUC
+#ifndef WIN32
 #include "resource.h"
+#endif
 KatData *
-getCustomResource( _In_ PSTR resourceName, _In_ PSTR /* resourceType */)
+getCustomResource( _In_ PCSTR resourceName, _In_ PCSTR /* resourceType */)
 {
     PCCHAR pbData = nullptr;
     SIZE_T cbData = GetResourceBytes((const char *)resourceName, &pbData);
@@ -980,7 +982,7 @@ getCustomResource( _In_ PSTR resourceName, _In_ PSTR /* resourceType */)
 
 #endif
 
-void printPlatformInformation( _In_z_ char * text )
+void printPlatformInformation( _In_z_ const char * text )
 {
 
     iprint( "\n%s "
@@ -1227,7 +1229,7 @@ initTestInfrastructure( int argc, _In_reads_( argc ) char * argv[] )
 
     SymCryptInit();
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
     getPlatformInformation();
 #endif
 
@@ -1279,7 +1281,7 @@ initTestInfrastructure( int argc, _In_reads_( argc ) char * argv[] )
     printOutput( 0 );
 }
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
 VOID
 callKernelmodeTests()
 {
@@ -1524,7 +1526,7 @@ VOID
 runFunctionalTests()
 {
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
     if( g_runKernelmodeTest )
     {
         runKernelmodeTests();
@@ -1578,7 +1580,7 @@ runFunctionalTests()
 
     testEcc();
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
     testIEEE802_11SaeCustom();
 #endif
 

--- a/unittest/lib/main_exe_common.cpp
+++ b/unittest/lib/main_exe_common.cpp
@@ -3,7 +3,7 @@
 //
 
 
-PSTR testDriverName = TESTDRIVER_NAME;
+PCSTR testDriverName = TESTDRIVER_NAME;
 
 const char * g_implementationNames[] = 
 {

--- a/unittest/lib/main_sys_common.cpp
+++ b/unittest/lib/main_sys_common.cpp
@@ -10,7 +10,12 @@
 #include <ntddk.h>
 #include <windef.h>
 #include <symcrypt.h>
+#if WIN32 && __GNUC__
+#include <um/wincrypt.h>
+#include <shared/bcrypt.h>
+#else
 #include <bcrypt.h>
+#endif
 
 #include "ioctlDefs.h"
 
@@ -19,7 +24,7 @@ typedef VOID (SYMCRYPT_CALL * SelfTestFn)();
 typedef struct _SELFTEST_INFO
 {
     SelfTestFn  f;
-    LPSTR       name;
+    LPCSTR      name;
 } SELFTEST_INFO;
 
 ULONGLONG g_nDpcsOnCpu[64];

--- a/unittest/lib/msbignum_implementations.cpp
+++ b/unittest/lib/msbignum_implementations.cpp
@@ -13,7 +13,7 @@
 #define SCRATCH_BUF_OFFSET  (1 << 15)
 #define SCRATCH_BUF_SIZE    (1 << 15)
 
-char * ImpMsBignum::name = "MsBignum";
+const char * ImpMsBignum::name = "MsBignum";
 
 bigctx_t g_BignumCtx = { 0 };
 

--- a/unittest/lib/perf.cpp
+++ b/unittest/lib/perf.cpp
@@ -31,7 +31,7 @@ double g_tscFreq;
 
 #if (SYMCRYPT_MS_VC || SYMCRYPT_GNUC) && (SYMCRYPT_CPU_AMD64 || SYMCRYPT_CPU_X86)
     // Windows or Linux, x86 or AMD64
-    #if SYMCRYPT_MS_VC
+    #if SYMCRYPT_MS_VC || WIN32
         #include <intrin.h>
     #else
         #include <x86intrin.h>
@@ -100,7 +100,7 @@ double g_tscFreq;
 
 BOOLEAN g_perfClockScaling = ENABLE_PERF_CLOCK_SCALING;
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
     #define ALLOCA( n ) _alloca( n )
 #else
     #define ALLOCA( n ) alloca( n )
@@ -151,7 +151,7 @@ GET_PERF_CLOCK()
 }
 */
 
-PSTR g_perfUnits = PERF_UNIT;
+PCSTR g_perfUnits = PERF_UNIT;
 
 PVOID g_stackAllocLinkedList;     // We put alloca's in a linked list so the compiler won't optimize it away.
 
@@ -1041,8 +1041,8 @@ VOID measurePerfData(
 }
 
 const struct {
-    UINT32  exKeyParam;
-    char *  str;
+    UINT32       exKeyParam;
+    const char * str;
 } g_exKeyParamMapping[] = {
     { 0,                                    "   " },
     { PERF_KEY_SECRET,                      "s  " },
@@ -1255,7 +1255,7 @@ measurePerf()
 {
     iprint( "\nStarting performance measurements...\n" );
 
-    #if SYMCRYPT_MS_VC
+    #if SYMCRYPT_MS_VC || WIN32
     int oldPriority = GetThreadPriority( GetCurrentThread() );
 
     CHECK( SetThreadPriority( GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL ), "Failed to set priority" );
@@ -1264,7 +1264,7 @@ measurePerf()
     DWORD_PTR affinitymask = (DWORD_PTR)1 << GetCurrentProcessorNumber();
     affinitymask = SetThreadAffinityMask( GetCurrentThread(), affinitymask );
     CHECK( affinitymask != 0, "Failed to set affinity mask" );
-    #endif // SYMCRYPT_MS_VC
+    #endif // SYMCRYPT_MS_VC || SYMCRYPT_GNUC && WIN32
 
     initPerfSystem();
 
@@ -1277,11 +1277,11 @@ measurePerf()
     }
 
 
-    #if SYMCRYPT_MS_VC
+    #if SYMCRYPT_MS_VC || WIN32
     CHECK( SetThreadAffinityMask( GetCurrentThread(), affinitymask ) != 0, "Failed to restore affinity mask" );
     CHECK( GetThreadPriority( GetCurrentThread() ) == THREAD_PRIORITY_TIME_CRITICAL, "Thread priority decay" );
     CHECK( SetThreadPriority( GetCurrentThread(), oldPriority ), "Failed to set priority" );
-    #endif // SYMCRYPT_MS_VC
+    #endif // SYMCRYPT_MS_VC || SYMCRYPT_GNUC && WIN32
 
     print( ".%c.\n", ' ' + (g_fixedTimeLoopVariable)%(127-' '));    // DO NOT REMOVE, ensures that do-busy work isn't optimized away
 

--- a/unittest/lib/printtable.cpp
+++ b/unittest/lib/printtable.cpp
@@ -202,7 +202,7 @@ PrintTable::print( String heading )
     {
         ::print( "%*s:", colSize[0]-1, m_rows[r].c_str() );
 
-        char * sep = " ";
+        const char * sep = " ";
         for( SIZE_T c=0; c<nCols; c++ )
         {
             ::print( "%-*s%*s", nSpacesBetweenColumns, sep, colSize[ c+1 ], m_items[ make_pair( m_rows[r], m_cols[c] ) ].c_str() );

--- a/unittest/lib/ref_implementations.cpp
+++ b/unittest/lib/ref_implementations.cpp
@@ -9,7 +9,7 @@
 
 #if INCLUDE_IMPL_REF
 
-char * ImpRef::name = "Ref";
+const char * ImpRef::name = "Ref";
 
 ///////////////////////////////////////////////////////
 // Poly1305

--- a/unittest/lib/rndDriver.cpp
+++ b/unittest/lib/rndDriver.cpp
@@ -9,7 +9,7 @@
 
 typedef struct _FUNCTION_RECORD {
     RNDD_TEST_FN    func;
-    char *          name;
+    const char *    name;
     volatile INT64  count;
     UINT32          weight;
     } FUNCTION_RECORD, *PFUNCTION_RECORD;
@@ -59,7 +59,7 @@ recomputeBuckets()
 
 
 VOID
-rnddRegisterTestFunction( RNDD_TEST_FN func, char * name, UINT32 weight )
+rnddRegisterTestFunction( RNDD_TEST_FN func, _In_ PCSTR name, UINT32 weight )
 {
     std::unique_ptr<FUNCTION_RECORD> p(new FUNCTION_RECORD);
     p->func = func;
@@ -107,7 +107,7 @@ rnddRegisterInvariantFunction( RNDD_TEST_FN func )
 ULONGLONG
 getTimeInMs()    // Will have to move it to the main_exe or main_dll when we support kernel mode
 {
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
     return GetTickCount64();
 #elif SYMCRYPT_GNUC && defined(__linux__)
     struct timespec ts;

--- a/unittest/lib/rsa32_implementations.cpp
+++ b/unittest/lib/rsa32_implementations.cpp
@@ -10,9 +10,9 @@
 
 
 
-char * ImpRsa32::name = "Rsa32";
+const char * ImpRsa32::name = "Rsa32";
 
-char * ImpRsa32b::name = "Rsa32b";
+const char * ImpRsa32b::name = "Rsa32b";
 
 
 #define RSA32_2DES_BLOCK_SIZE    RSA32_DES_BLOCK_SIZE

--- a/unittest/lib/sc_imp_blockcipherpattern.cpp
+++ b/unittest/lib/sc_imp_blockcipherpattern.cpp
@@ -106,3 +106,6 @@ BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>::decrypt( PBYTE pbChain, SIZE_T cbChain,
     verifyXmmRegisters();
 }
 
+
+template class BlockCipherImpState<ImpXxx, AlgXxx, ModeXxx>;
+template class BlockCipherImp<ImpXxx, AlgXxx, ModeXxx>;

--- a/unittest/lib/sc_imp_kdfpattern.cpp
+++ b/unittest/lib/sc_imp_kdfpattern.cpp
@@ -4,26 +4,6 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license. 
 //
 
-template<> VOID algImpKeyPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T keySize );
-template<> VOID algImpCleanPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3 );
-template<> VOID algImpDataPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T dataSize );
-
-//
-// Empty constructor. 
-//
-template<>
-KdfImp<ImpXxx, AlgXxx, BaseAlgXxx>::KdfImp()
-{
-    m_perfDataFunction = &algImpDataPerfFunction <ImpXxx, AlgXxx, BaseAlgXxx>;
-    m_perfKeyFunction  = &algImpKeyPerfFunction  <ImpXxx, AlgXxx, BaseAlgXxx>;
-    m_perfCleanFunction= &algImpCleanPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>;
-}
-
-template<>
-KdfImp<ImpXxx, AlgXxx, BaseAlgXxx>::~KdfImp<ImpXxx, AlgXxx, BaseAlgXxx>()
-{
-}
-
 template<>
 VOID 
 algImpKeyPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>( PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T keySize )
@@ -41,4 +21,19 @@ algImpCleanPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>( PBYTE buf1, PBYTE buf2, PBY
     SymCryptWipeKnownSize( buf1, sizeof( SYMCRYPT_XXX_EXPANDED_KEY ) );
 }
 
+//
+// Empty constructor.
+//
+template<>
+KdfImp<ImpXxx, AlgXxx, BaseAlgXxx>::KdfImp()
+{
+    m_perfDataFunction = &algImpDataPerfFunction <ImpXxx, AlgXxx, BaseAlgXxx>;
+    m_perfKeyFunction  = &algImpKeyPerfFunction  <ImpXxx, AlgXxx, BaseAlgXxx>;
+    m_perfCleanFunction= &algImpCleanPerfFunction<ImpXxx, AlgXxx, BaseAlgXxx>;
+}
+
+template<>
+KdfImp<ImpXxx, AlgXxx, BaseAlgXxx>::~KdfImp<ImpXxx, AlgXxx, BaseAlgXxx>()
+{
+}
 

--- a/unittest/lib/sc_implementations.cpp
+++ b/unittest/lib/sc_implementations.cpp
@@ -462,7 +462,7 @@ SymCryptRc2CfbDecrypt(
 #define SYMCRYPT_2DES_EXPANDED_KEY  SYMCRYPT_3DES_EXPANDED_KEY
 #define SymCrypt2DesExpandKey       SymCrypt3DesExpandKey
 
-char * ImpSc::name = "SymCrypt";
+const char * ImpSc::name = "SymCrypt";
 
 #define IMP_NAME    SYMCRYPT
 #define IMP_Name    Sc
@@ -666,33 +666,33 @@ char * ImpSc::name = "SymCrypt";
 #define ALG_Name    Pbkdf2
 
 #define ALG_Base    HmacMd5
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_pbkdf2pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha1
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_pbkdf2pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha256
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_pbkdf2pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha384
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_pbkdf2pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha512
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_pbkdf2pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    AesCmac
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_pbkdf2pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #undef ALG_NAME
@@ -702,33 +702,33 @@ char * ImpSc::name = "SymCrypt";
 #define ALG_Name    Sp800_108
 
 #define ALG_Base    HmacMd5
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_sp800_108pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha1
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_sp800_108pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha256
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_sp800_108pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha384
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_sp800_108pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha512
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_sp800_108pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    AesCmac
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_sp800_108pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #undef ALG_NAME
@@ -748,18 +748,18 @@ char * ImpSc::name = "SymCrypt";
 #define ALG_Name    TlsPrf1_2
 
 #define ALG_Base    HmacSha256
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_tlsprf1_2pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha384
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_tlsprf1_2pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #define ALG_Base    HmacSha512
-#include "sc_imp_kdfpattern.cpp"
 #include "sc_imp_tlsprf1_2pattern.cpp"
+#include "sc_imp_kdfpattern.cpp"
 #undef ALG_Base
 
 #undef ALG_NAME
@@ -3988,7 +3988,7 @@ const HASH_INFO hashInfoTable[] = {
     { NULL },
 };
 
-PCHASH_INFO getHashInfo( PCSTR pcstrName )
+FORCEINLINE PCHASH_INFO getHashInfo( PCSTR pcstrName )
 {
     for( int i=0; hashInfoTable[i].name != NULL; i++ )
     {
@@ -6920,7 +6920,7 @@ EccImp<ImpSc, AlgEcdh>::~EccImp()
 }
 
 //============================
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
 template<>
 VOID
 algImpKeyPerfFunction<ImpSc, AlgIEEE802_11SaeCustom>( PBYTE buf1, PBYTE buf2, PBYTE buf3, SIZE_T keySize )
@@ -7127,7 +7127,7 @@ addSymCryptAlgs()
     addImplementationToGlobalList<EccImp<ImpSc, AlgEcdsaVerify>>();
     addImplementationToGlobalList<EccImp<ImpSc, AlgEcdh>>();
 
-#if SYMCRYPT_MS_VC
+#if SYMCRYPT_MS_VC || WIN32
     addImplementationToGlobalList<ArithImp<ImpSc, AlgIEEE802_11SaeCustom>>();
 #endif
 

--- a/unittest/lib/testAesCtrDrbg.cpp
+++ b/unittest/lib/testAesCtrDrbg.cpp
@@ -116,7 +116,7 @@ RngSp800_90MultiImp::RngSp800_90MultiImp( String algName )
     m_algorithmName = algName;
 
     String sumAlgName;
-    char * sepStr = "<";
+    const char * sepStr = "<";
 
     for( RngImpPtrVector::const_iterator i = m_imps.begin(); i != m_imps.end(); ++i )
     {

--- a/unittest/lib/testAuthEnc.cpp
+++ b/unittest/lib/testAuthEnc.cpp
@@ -64,7 +64,7 @@ AuthEncMultiImp::AuthEncMultiImp( String algName )
     m_algorithmName = algName;
 
     String sumAlgName;
-    char * sepStr = "<";
+    const char * sepStr = "<";
 
     for( AuthEncImpPtrVector::const_iterator i = m_imps.begin(); i != m_imps.end(); ++i )
     {

--- a/unittest/lib/testBlockCiphers.cpp
+++ b/unittest/lib/testBlockCiphers.cpp
@@ -37,7 +37,7 @@ BlockCipherMultiImp::BlockCipherMultiImp( String algName )
     m_algorithmName = algName;
 
     String sumImpName;
-    char * sepStr = "<";
+    const char * sepStr = "<";
 
     for( BlockCipherImpPtrVector::const_iterator i = m_imps.begin(); i != m_imps.end(); ++i )
     {

--- a/unittest/lib/testDh.cpp
+++ b/unittest/lib/testDh.cpp
@@ -178,7 +178,7 @@ VOID generateDlGroups()
     UINT32 bitSize;
     UINT32 primResult;
 
-    char * sep = " [group safeprime:";
+    const char * sep = " [group safeprime:";
     UINT32 previousSize = 0;
 
     if( g_nDlgroups >= MAX_TEST_DLGROUPS )

--- a/unittest/lib/testEcc.cpp
+++ b/unittest/lib/testEcc.cpp
@@ -26,7 +26,7 @@ testEccEcdsaKats();
 #define SYMCRYPT_ECC_CURVE_NUMSP512T1         "numsP512t1"
 
 typedef struct _SYMCRYPT_ECC_CURVES {
-    LPSTR                       pszCurveName;
+    LPCSTR                      pszCurveName;
     PCSYMCRYPT_ECURVE_PARAMS    pParams;
     PSYMCRYPT_ECURVE            pCurve;
 } SYMCRYPT_ECC_CURVES;
@@ -60,7 +60,7 @@ SYMCRYPT_ECC_CURVES rgbInternalCurves[] = {
 
 
 typedef struct _SYMCRYPT_ECC_HASH_ALGORITHMS {
-    LPSTR                       pszHashName;
+    LPCSTR                      pszHashName;
     PCSYMCRYPT_HASH             pHash;
 } SYMCRYPT_ECC_HASH_ALGORITHMS;
 
@@ -80,7 +80,7 @@ SYMCRYPT_ECC_HASH_ALGORITHMS rgbHashAlgorithms[] = {
 //
 ////////////////////////////////////////////////////////////////////
 
-LPSTR rgbPrivateKeyFormatNames[] = {
+LPCSTR rgbPrivateKeyFormatNames[] = {
     "Null",
     "Canonical",
     "DivH",

--- a/unittest/lib/testKdf.cpp
+++ b/unittest/lib/testKdf.cpp
@@ -46,7 +46,7 @@ KdfMultiImp::KdfMultiImp( String algName )
     m_algorithmName = algName;
 
     String sumImpName;
-    char * sepStr = "<";
+    const char * sepStr = "<";
 
     for( KdfImpPtrVector::const_iterator i = m_imps.begin(); i != m_imps.end(); ++i )
     {

--- a/unittest/lib/testMac.cpp
+++ b/unittest/lib/testMac.cpp
@@ -43,7 +43,7 @@ MacMultiImp::MacMultiImp( String algName )
     m_algorithmName = algName;
 
     String sumImpName;
-    char * sepStr = "<";
+    const char * sepStr = "<";
 
     for( MacImpPtrVector::const_iterator i = m_imps.begin(); i != m_imps.end(); ++i )
     {

--- a/unittest/lib/testRsaSign.cpp
+++ b/unittest/lib/testRsaSign.cpp
@@ -233,7 +233,7 @@ VOID rsaTestKeysGenerate()
         };
     UINT32 bitSize;
 
-    char * sep = " [test key gen: ";
+    const char * sep = " [test key gen: ";
     UINT32 previousSize = 0;
 
     if( g_nRsaTestKeyBlobs >= MAX_RSA_TESTKEYS )

--- a/unittest/lib/testStreamCipher.cpp
+++ b/unittest/lib/testStreamCipher.cpp
@@ -45,7 +45,7 @@ StreamCipherMultiImp::StreamCipherMultiImp( String algName )
     m_algorithmName = algName;
 
     String sumImpName;
-    char * sepStr = "<";
+    const char * sepStr = "<";
 
     for( StreamCipherImpPtrVector::const_iterator i = m_imps.begin(); i != m_imps.end(); ++i )
     {

--- a/unittest/lib/testTlsCbcHmac.cpp
+++ b/unittest/lib/testTlsCbcHmac.cpp
@@ -40,7 +40,7 @@ TlsCbcHmacMultiImp::TlsCbcHmacMultiImp( String algName )
     m_algorithmName = algName;
 
     String sumImpName;
-    char * sepStr = "<";
+    const char * sepStr = "<";
 
     for( TlsCbcHmacImpPtrVector::const_iterator i = m_imps.begin(); i != m_imps.end(); ++i )
     {
@@ -166,8 +166,8 @@ VOID
 testTlsCbcHmacAlgorithms()
 {
     std::unique_ptr<TlsCbcHmacMultiImp> pImp;
-       
-    char * sep = "    ";
+
+    const char * sep = "    ";
     BOOL doneAnything = FALSE;
 
     pImp.reset( new TlsCbcHmacMultiImp( "TlsCbcHmacSha1" ) );

--- a/unittest/lib/testXts.cpp
+++ b/unittest/lib/testXts.cpp
@@ -45,7 +45,7 @@ XtsMultiImp::XtsMultiImp( String algName )
     m_algorithmName = algName;
 
     String sumImpName;
-    char * sepStr = "<";
+    const char * sepStr = "<";
 
     for( XtsImpPtrVector::const_iterator i = m_imps.begin(); i != m_imps.end(); ++i )
     {

--- a/unittest/lib/testhash.cpp
+++ b/unittest/lib/testhash.cpp
@@ -53,7 +53,7 @@ VOID
 HashMultiImp::setImpName()
 {
     String sumAlgName;
-    char * sepStr = "<";
+    const char * sepStr = "<";
 
     for( HashImpPtrVector::const_iterator i = m_imps.begin(); i != m_imps.end(); ++i )
     {
@@ -266,7 +266,7 @@ ParallelHashMultiImp::ParallelHashMultiImp( String algName )
     m_algorithmName = algName;
 
     String sumAlgName;
-    char * sepStr = "<";
+    const char * sepStr = "<";
 
     for( ParallelHashImpPtrVector::const_iterator i = m_imps.begin(); i != m_imps.end(); ++i )
     {

--- a/unittest/symcryptunittest.rc
+++ b/unittest/symcryptunittest.rc
@@ -4,20 +4,20 @@
 // Copyright (c) Microsoft Corporation. Licensed under the MIT license.
 //
 
-kat_hash.dat                    KAT_HASH                        "..\kat_hash.dat"
-kat_mac.dat                     KAT_MAC                         "..\kat_mac.dat"
-kat_blockcipher.dat             KAT_BLOCK_CIPHER                "..\kat_blockcipher.dat"
-kat_authenc.dat                 KAT_AUTHENC                     "..\kat_authenc.dat"
-kat_streamcipher.dat            KAT_STREAM_CIPHER               "..\kat_streamcipher.dat"
-kat_rng.dat                     KAT_RNG                         "..\kat_rng.dat"
-kat_kdf.dat                     KAT_KDF                         "..\kat_kdf.dat"
-kat_xts.dat                     KAT_XTS                         "..\kat_xts.dat"
-kat_ecdsa.dat                   KAT_ECDSA                       "..\kat_ecdsa.dat"
-kat_IEEE802_11SaeCustom.dat     KAT_SAE_CUSTOM                  "..\kat_IEEE802_11SaeCustom.dat"
-kat_rsaSign.dat                 KAT_RSA_SIGN                    "..\kat_rsaSign.dat"
-kat_rsaEnc.dat                  KAT_RSA_ENC                     "..\kat_rsaEnc.dat"
-kat_dh.dat                      KAT_DH                          "..\kat_dh.dat"
-kat_dsa.dat                     KAT_DSA                         "..\kat_dsa.dat"
+kat_hash.dat                    KAT_HASH                        "..\\kat_hash.dat"
+kat_mac.dat                     KAT_MAC                         "..\\kat_mac.dat"
+kat_blockcipher.dat             KAT_BLOCK_CIPHER                "..\\kat_blockcipher.dat"
+kat_authenc.dat                 KAT_AUTHENC                     "..\\kat_authenc.dat"
+kat_streamcipher.dat            KAT_STREAM_CIPHER               "..\\kat_streamcipher.dat"
+kat_rng.dat                     KAT_RNG                         "..\\kat_rng.dat"
+kat_kdf.dat                     KAT_KDF                         "..\\kat_kdf.dat"
+kat_xts.dat                     KAT_XTS                         "..\\kat_xts.dat"
+kat_ecdsa.dat                   KAT_ECDSA                       "..\\kat_ecdsa.dat"
+kat_IEEE802_11SaeCustom.dat     KAT_SAE_CUSTOM                  "..\\kat_IEEE802_11SaeCustom.dat"
+kat_rsaSign.dat                 KAT_RSA_SIGN                    "..\\kat_rsaSign.dat"
+kat_rsaEnc.dat                  KAT_RSA_ENC                     "..\\kat_rsaEnc.dat"
+kat_dh.dat                      KAT_DH                          "..\\kat_dh.dat"
+kat_dsa.dat                     KAT_DSA                         "..\\kat_dsa.dat"
 
 
 


### PR DESCRIPTION
make windows bits more compatible with gcc/clang to catch more problems

fix ISO C/C++ violations (const char -> char, template use before specialization, invalid string escapes, missing specialization definitions)

fix SymCryptFatalEnv* stack clash code emit failures under gcc

add IPO / LTCG support to root CMakeLists.txt (optional, disabled for Debug, opt-out for Release)

add windows (10) kits discovery to root CMakeLists.txt

