### PR TITLE
Fix C4319 Warnings

### DIFF
--- a/lib/parhash.c
+++ b/lib/parhash.c
@@ -457,7 +457,7 @@ SymCryptParallelHashProcess(
             todo = SYMCRYPT_MIN( todo, pWork[i]->cbData );
         }
 
-        nBytes = todo & ~(pHash->inputBlockSize - 1 );
+        nBytes = todo & (SIZE_T)(~(pHash->inputBlockSize - 1 ));
 
         (*pParHash->parAppendFunc)( pWork, nPar, nBytes, pbFixedScratch, cbFixedScratch );
 

--- a/lib/rsa_padding.c
+++ b/lib/rsa_padding.c
@@ -297,7 +297,7 @@ SymCryptRsaPkcs1RemoveEncryptionPadding(
     mPaddingError |= SymCryptMask32LtU31( iFirstZero, 10 );
 
     // Compute the # bytes of the message; 0 if there was a padding error
-    cbPlaintextResult = ~mPaddingError & (cbPkcs1Format - iFirstZero - 1);
+    cbPlaintextResult = ~mPaddingError & (UINT32)(cbPkcs1Format - iFirstZero - 1);
 
     // We're done if the caller didn't want the actual message, but only the size.
     // We do that before checking the size of the plaintext buffer so that callers who


### PR DESCRIPTION
On a fresh clone using the main branch, when trying to build for the first time and running
`py -3 scripts/build.py cmake build`

I get the following 2 warnings that are treated as errors:

SymCrypt\lib\parhash.c(460,25): warning C4319: '~': zero extending 'const UINT32' to 'SIZE_T' of greater size
SymCrypt\lib\rsa_padding.c(300,25): warning C4319: '~': zero extending 'UINT32' to 'SIZE_T' of greater size

This PR makes the appropriate casts for a successful build